### PR TITLE
add documentation for cd to the piko dir

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,6 +9,7 @@ register upstream services to handle incoming requests proxied by Piko.
 Start by cloning Piko and building the Piko Docker image:
 ```shell
 git clone git@github.com:andydunstall/piko.git
+cd piko
 make piko
 make image
 ```


### PR DESCRIPTION
I think there is a missing `cd` in the tutorial, so this PR adds the cd