### PR TITLE
cli: extend docs

### DIFF
--- a/cli/agent/command.go
+++ b/cli/agent/command.go
@@ -36,6 +36,10 @@ address.
 Such as if you have a service running at 'localhost:3000', you can register
 endpoint 'my-endpoint' that forwards requests to that local service.
 
+The agent supports both YAML configuration and command line flags. Configure
+a YAML file using '--config.path'. When enabling '--config.expand-env', Piko
+will expand environment variables in the loaded YAML configuration.
+
 Examples:
   # Register an endpoint with ID 'my-endpoint-123' that forwards requests to
   # to 'localhost:3000'.

--- a/cli/command.go
+++ b/cli/command.go
@@ -9,15 +9,40 @@ import (
 )
 
 func NewCommand() *cobra.Command {
-	cobra.EnableCommandSorting = false
-
 	cmd := &cobra.Command{
 		Use:          "piko [command] (flags)",
 		SilenceUsage: true,
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},
-		Short: "piko proxy",
+		Long: `Piko is a reverse proxy that allows you to expose an endpoint
+that isn’t publicly routable (known as tunnelling).
+
+The Piko server is responsible for routing incoming proxy requests to upstream
+services. Upstream services open outbound-connections to the server and
+register endpoints. Piko will then route incoming requests to the appropriate
+upstream service via the upstreams outbound-only connection.
+
+The server may be hosted as a cluster of nodes.
+
+Start a server node with:
+
+  $ piko server
+
+You can also inspect the status of the server using:
+
+  $ piko status
+
+To register an upstream service, use the Piko agent. The agent is a lightweight
+proxy that runs alongside your services. It connects to the Piko server,
+registers the configured endpoints, then forwards incoming requests to your
+services.
+
+Such as to register endpoint 'my-endpoint' that forwards incoming requests to
+'localhost:4000', use:
+
+  $ piko agent --endpoints my-endpoint/localhost:4000
+`,
 	}
 
 	cmd.AddCommand(agent.NewCommand())

--- a/cli/server/command.go
+++ b/cli/server/command.go
@@ -22,20 +22,25 @@ func NewCommand() *cobra.Command {
 		Short: "start a server node",
 		Long: `Start a server node.
 
-The Piko server is responsible for proxying requests from proxy clients to
-registered upstream listeners.
+The Piko server is responsible for routing incoming proxy requests to upstream
+services. Upstream services open outbound-connections to the server and
+register endpoints. Piko will then route incoming requests to the appropriate
+upstream service via the upstreams outbound-only connection.
 
 Piko may run as a cluster of nodes for fault tolerance and scalability. Use
 '--cluster.join' to configure addresses of existing members in the cluster
 to join.
 
+The server supports both YAML configuration and command line flags. Configure
+a YAML file using '--config.path'. When enabling '--config.expand-env', Piko
+will expand environment variables in the loaded YAML configuration.
+
 Examples:
-  # Start a Piko server.
+  # Start a Piko server node.
   piko server
 
-  # Start a Piko server, listening for proxy connections on :7000, upstream
-  # connections on :7001 and admin connections on :7002.
-  piko server --proxy.bind-addr :7000 --upstream.bind-addr :7001 --admin.bind-addr :7002
+  # Load configuration from YAML.
+  piko server --config.path ./server.yaml
 
   # Start a Piko server and join an existing cluster by specifying each member.
   piko server --cluster.join 10.26.104.14,10.26.104.75


### PR DESCRIPTION
Improves the CLI help message for commands `piko`, `piko server` and `piko agent` 