### PR TITLE
helm: add piko helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+IMAGE_TAG ?= $(shell git rev-parse HEAD)
+
 .PHONY: all
 all: piko
 
@@ -40,5 +42,5 @@ coverage:
 
 .PHONY: image
 image:
-	docker build . -f build/Dockerfile -t piko:$(shell git rev-parse HEAD)
-	docker tag piko:$(shell git rev-parse HEAD) piko:latest
+	docker build . -f build/Dockerfile -t piko:$(IMAGE_TAG)
+	docker tag piko:$(IMAGE_TAG) piko:latest

--- a/docs/manage/kubernetes.md
+++ b/docs/manage/kubernetes.md
@@ -129,3 +129,8 @@ spec:
 You can then setup the any required load balancers (such as a Kubernetes
 Gatweay) or services to route requests to the server.
 to Piko. 
+
+## Helm
+
+Piko includes a simple helm chart at [operations/helm](../../operations/helm).
+This chart creates a headless service and StatefulSet as described above.

--- a/operations/helm/piko/Chart.yaml
+++ b/operations/helm/piko/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: piko
+description: Piko proxy
+
+home: https://github.com/andydunstall/piko
+
+version: 0.1.0
+
+appVersion: "0.1.0"
+
+sources:
+  - https://github.com/dragonflydb/dragonfly

--- a/operations/helm/piko/templates/_helpers.tpl
+++ b/operations/helm/piko/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "piko.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "piko.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "piko.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "piko.labels" -}}
+helm.sh/chart: {{ include "piko.chart" . }}
+{{ include "piko.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "piko.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "piko.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "piko.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "piko.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/operations/helm/piko/templates/configmap.yaml
+++ b/operations/helm/piko/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "piko.fullname" . }}
+  labels:
+    {{- include "piko.labels" . | nindent 4 }}
+data:
+  server.yaml: |
+    cluster:
+      node_id_prefix: ${POD_NAME}-
+      join:
+        - {{ include "piko.fullname" . }}

--- a/operations/helm/piko/templates/service.yaml
+++ b/operations/helm/piko/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "piko.fullname" . }}
+  labels:
+    {{- include "piko.labels" . | nindent 4 }}
+spec:
+  ports:
+  - port: {{ .Values.server.proxyPort }}
+    name: proxy
+    protocol: TCP
+  - port: {{ .Values.server.upstreamPort }}
+    name: upstream
+    protocol: TCP
+  - port: {{ .Values.server.adminPort }}
+    name: admin
+    protocol: TCP
+  clusterIP: None
+  selector:
+    {{- include "piko.selectorLabels" . | nindent 4 }}

--- a/operations/helm/piko/templates/serviceaccount.yaml
+++ b/operations/helm/piko/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "piko.serviceAccountName" . }}
+  labels:
+    {{- include "piko.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/operations/helm/piko/templates/statefulset.yaml
+++ b/operations/helm/piko/templates/statefulset.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "piko.fullname" . }}
+  labels:
+    {{- include "piko.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "piko.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "piko.fullname" . }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "piko.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "piko.serviceAccountName" . }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+      - name: piko
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        ports:
+          - containerPort: {{ .Values.server.proxyPort }}
+            name: proxy
+          - containerPort: {{ .Values.server.upstreamPort }}
+            name: upstream
+          - containerPort: {{ .Values.server.adminPort }}
+            name: admin
+          - containerPort: {{ .Values.server.gossipPort }}
+            name: gossip
+        readinessProbe:
+          {{- toYaml .Values.readinessProbe | nindent 12 }}
+        args:
+          - server
+          - --config.path
+          - /config/server.yaml
+          - --config.expand-env
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        volumeMounts:
+          - name: config
+            mountPath: "/config"
+            readOnly: true
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "piko.fullname" . }}
+            items:
+            - key: "server.yaml"
+              path: "server.yaml"
+

--- a/operations/helm/piko/values.yaml
+++ b/operations/helm/piko/values.yaml
@@ -1,0 +1,41 @@
+replicaCount: 1
+
+image:
+  repository: piko
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+server:
+  # -- Specifies the proxy port to listen on. The proxy port listens for
+  # requests that are forwarded to upstream services.
+  proxyPort: 8000
+  # -- Specifies the upstream port to listen on. The upstream port listens
+  # for connections from upstream service.
+  upstreamPort: 8001
+  # -- Specifies the admin port to listen on. The admin port exposes an API for
+  # metrics and observability.
+  adminPort: 8002
+  # -- Specifies the gossip port for inter-node traffic.
+  gossipPort: 8003
+
+terminationGracePeriodSeconds: 60
+
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: admin
+
+affinity: {}

--- a/server/server/admin/server.go
+++ b/server/server/admin/server.go
@@ -100,6 +100,7 @@ func (s *Server) Close() error {
 
 func (s *Server) registerRoutes() {
 	s.router.GET("/health", s.healthRoute)
+	s.router.GET("/ready", s.readyRoute)
 
 	if s.registry != nil {
 		s.router.GET("/metrics", s.metricsHandler())
@@ -107,6 +108,10 @@ func (s *Server) registerRoutes() {
 }
 
 func (s *Server) healthRoute(c *gin.Context) {
+	c.Status(http.StatusOK)
+}
+
+func (s *Server) readyRoute(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 


### PR DESCRIPTION
Fixes https://github.com/andydunstall/piko/issues/22

Adds a simple Helm chart that creates a headless service and statefulset of Piko nodes. Piko uses the headless service domain to resolve the other pods in the cluster. (Just trying to get started with a simple chart that can be extended later)