### PR TITLE
fix: forwarder copy body eof

### DIFF
--- a/cli/workload/requests.go
+++ b/cli/workload/requests.go
@@ -1,6 +1,7 @@
 package workload
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math/rand"
@@ -129,12 +130,14 @@ func runClient(ctx context.Context, conf *config.RequestsConfig, logger log.Logg
 	ticker := time.NewTicker(time.Duration(int(time.Second) / conf.Rate))
 	defer ticker.Stop()
 
+	body := make([]byte, conf.RequestSize)
+
 	client := &http.Client{}
 	for {
 		select {
 		case <-ticker.C:
 			endpointID := rand.Int() % conf.Endpoints
-			req, _ := http.NewRequest("GET", conf.Server.URL, nil)
+			req, _ := http.NewRequest("GET", conf.Server.URL, bytes.NewReader(body))
 			req.Header.Set("x-piko-endpoint", strconv.Itoa(endpointID))
 			resp, err := client.Do(req)
 			if err != nil {

--- a/workload/config/requests.go
+++ b/workload/config/requests.go
@@ -16,6 +16,9 @@ type RequestsConfig struct {
 	// Endpoints is the number of available endpoint IDs.
 	Endpoints int `json:"endpoints" yaml:"endpoints"`
 
+	// RequestSize is the size of each request.
+	RequestSize int `json:"request_size" yaml:"request_size"`
+
 	Server ServerConfig `json:"server" yaml:"server"`
 
 	Log log.Config `json:"log" yaml:"log"`
@@ -67,6 +70,15 @@ The number of available endpoint IDs to send requests to.
 
 On each request, the client selects a random endpoint ID from 0 to
 'endpoints'.`,
+	)
+
+	fs.IntVar(
+		&c.RequestSize,
+		"request-size",
+		1024,
+		`
+The size of each request. As the upstream echos the response body, the response
+will have the same size.`,
 	)
 
 	fs.StringVar(


### PR DESCRIPTION
When the HTTP response body is copied, it seems to sometimes fail due to the request context being cancelled. As a temporary workaround, this copies the response body before the context is cancelled.