### PR TITLE
client: add go sdk interface

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,38 @@
+package piko
+
+import "context"
+
+// Piko manages registering endpoints with the server and listening for
+// incoming connections to those endpoints.
+//
+// The client establishes an outbound-only connection to the server, so never
+// exposes any ports itself. Connections to the registered endpoints will be
+// load balanced by the server to any upstreams registered for the endpoint.
+// Those connections will then be forwarded to the upstream via the clients
+// outbound-only connection.
+//
+// NOTE the client is not yet functional.
+type Piko struct {
+}
+
+// Connect establishes a new outbound connection with the Piko server. This
+//
+// This will block until the client can connect.
+//nolint
+func Connect(ctx context.Context, opts ...ConnectOption) (*Piko, error) {
+	return nil, nil
+}
+
+// Listen registers the endpoint with the given ID and returns a [Listener]
+// which accepts incoming connections for that endpoint.
+//
+// [Listener] is a [net.Listener].
+//nolint
+func (p *Piko) Listen(ctx context.Context, endpointID string) (Listener, error) {
+	return nil, nil
+}
+
+// Close closes the connection to Piko and any open listeners.
+func (p *Piko) Close() error {
+	return nil
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,38 @@
+package piko_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	piko "github.com/andydunstall/piko/client"
+)
+
+func Example() {
+	pikoAPIKey := os.Getenv("PIKO_API_KEY")
+
+	// Connect to the Piko server.
+	piko, err := piko.Connect(
+		context.Background(),
+		piko.WithAPIKey(pikoAPIKey),
+		piko.WithURL("http://piko.example.com:8001"),
+	)
+	if err != nil {
+		panic("connect: " + err.Error())
+	}
+
+	// Listen on endpoint 'my-endpoint'.
+	ln, err := piko.Listen(context.Background(), "my-endpoint")
+	if err != nil {
+		panic("listen: " + err.Error())
+	}
+
+	// Use the listener to accept HTTP requests.
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello world!")
+	}
+	if err := http.Serve(ln, http.HandlerFunc(handler)); err != nil {
+		panic("http serve: " + err.Error())
+	}
+}

--- a/client/listener.go
+++ b/client/listener.go
@@ -1,0 +1,15 @@
+package piko
+
+import "net"
+
+// Listener is a [net.Listener] that accepts incoming connections for endpoints
+// registered with the server by the client.
+//
+// Closing the listener will unregister for the endpoint.
+type Listener interface {
+	net.Listener
+
+	// EndpointID returns the ID of the endpoint this is listening for
+	// connections on.
+	EndpointID() string
+}

--- a/client/options.go
+++ b/client/options.go
@@ -1,0 +1,33 @@
+package piko
+
+type connectOptions struct {
+	apiKey string
+	url    string
+}
+
+type ConnectOption interface {
+	apply(*connectOptions)
+}
+
+type apiKeyOption string
+
+func (o apiKeyOption) apply(opts *connectOptions) {
+	opts.apiKey = string(o)
+}
+
+// WithAPIKey configures the API key to authenticate the client.
+func WithAPIKey(key string) ConnectOption {
+	return apiKeyOption(key)
+}
+
+type urlOption string
+
+func (o urlOption) apply(opts *connectOptions) {
+	opts.url = string(o)
+}
+
+// WithURL configures the Piko server URL. Such as
+// 'https://piko.example.com:8001'.
+func WithURL(url string) ConnectOption {
+	return urlOption(url)
+}


### PR DESCRIPTION
Adds a basic interface for the Piko Go client. The client is not yet functional.