### PR TITLE
agentv2: add agent cli and configuration

### DIFF
--- a/agentv2/config/config.go
+++ b/agentv2/config/config.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+
+	"github.com/andydunstall/piko/pkg/log"
+	"github.com/spf13/pflag"
+)
+
+type EndpointConfig struct {
+	// ID is the endpoint ID to register.
+	ID string `json:"id" yaml:"id"`
+
+	// Addr is the address of the upstream service to forward to.
+	Addr string `json:"addr" yaml:"addr"`
+
+	// AccessLog indicates whether to log all incoming connections and requests
+	// for the endpoint.
+	AccessLog bool `json:"access_log" yaml:"access_log"`
+}
+
+func (c *EndpointConfig) Validate() error {
+	if c.ID == "" {
+		return fmt.Errorf("missing id")
+	}
+	if c.Addr == "" {
+		return fmt.Errorf("missing addr")
+	}
+	if _, ok := ParseAddrToURL(c.Addr); !ok {
+		return fmt.Errorf("invalid addr")
+	}
+	return nil
+}
+
+type Config struct {
+	Endpoints []EndpointConfig `json:"endpoints" yaml:"endpoints"`
+
+	// Token is used to authenticate the agent with the server.
+	Token string `json:"token" yaml:"token"`
+
+	Log log.Config `json:"log" yaml:"log"`
+}
+
+func (c *Config) Validate() error {
+	// Note don't validate the number of endpoints, as some commands don't
+	// require any.
+	for _, e := range c.Endpoints {
+		if err := e.Validate(); err != nil {
+			if e.ID != "" {
+				return fmt.Errorf("endpoint: %s: %w", e.ID, err)
+			}
+			return fmt.Errorf("endpoint: %w", err)
+		}
+	}
+
+	if err := c.Log.Validate(); err != nil {
+		return fmt.Errorf("log: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
+	fs.StringVar(
+		&c.Token,
+		"token",
+		"",
+		`
+A token to authenticate the connection to Piko.`,
+	)
+
+	c.Log.RegisterFlags(fs)
+}
+
+// ParseAddrToURL parses the given upstream address into a URL. Return false
+// if the address is invalid.
+//
+// The addr may be either a full URL, a host and port or just a port.
+func ParseAddrToURL(addr string) (*url.URL, bool) {
+	// Port only.
+	port, err := strconv.Atoi(addr)
+	if err == nil && port >= 0 && port < 0xffff {
+		return &url.URL{
+			Scheme: "http",
+			Host:   "localhost:" + addr,
+		}, true
+	}
+
+	// Host and port.
+	host, portStr, err := net.SplitHostPort(addr)
+	if err == nil {
+		return &url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort(host, portStr),
+		}, true
+	}
+
+	// URL.
+	u, err := url.Parse(addr)
+	if err == nil && u.Scheme != "" && u.Host != "" {
+		return u, true
+	}
+
+	return nil, false
+}

--- a/agentv2/config/config_test.go
+++ b/agentv2/config/config_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseAddrToURL(t *testing.T) {
+	tests := []struct {
+		addr string
+		url  *url.URL
+		ok   bool
+	}{
+		{
+			addr: "8080",
+			url: &url.URL{
+				Scheme: "http",
+				Host:   "localhost:8080",
+			},
+		},
+		{
+			addr: "1.2.3.4:8080",
+			url: &url.URL{
+				Scheme: "http",
+				Host:   "1.2.3.4:8080",
+			},
+		},
+		{
+			addr: "https://1.2.3.4:8080",
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "1.2.3.4:8080",
+			},
+		},
+		{
+			addr: "invalid",
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // for t.Parallel
+		t.Run(tt.addr, func(t *testing.T) {
+			u, ok := ParseAddrToURL(tt.addr)
+			if !ok {
+				assert.Equal(t, tt.ok, ok)
+				return
+			}
+			assert.Equal(t, tt.url, u)
+		})
+	}
+}

--- a/cli/agentv2/command.go
+++ b/cli/agentv2/command.go
@@ -1,0 +1,87 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/andydunstall/piko/agentv2/config"
+	pikoconfig "github.com/andydunstall/piko/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agentv2 [command] [flags]",
+		Short: "piko agent",
+		Long: `The Piko agent registers endpoints with Piko then forwards
+incoming connections for each endpoint to your upstream services.
+
+The agent opens a single outbound connection to the Piko server, which is used
+to proxy connections and requests. Therefore the agent never exposes a port.
+
+The agent supports both YAML configuration and command line flags. Configure
+a YAML file using '--config.path'. When enabling '--config.expand-env', Piko
+will expand environment variables in the loaded YAML configuration.
+
+Examples:
+  # Register HTTP endpoint 'my-endpoint' for forward to localhost:3000.
+  piko agent http my-endpoint 3000
+
+  # Start all configured endpoints.
+  piko agent start --config.file ./agent.yaml
+
+  # Ping the server.
+  piko agent ping
+`,
+		// TODO(andydunstall): Hide while in development.
+		Hidden: true,
+	}
+
+	var configPath string
+	cmd.PersistentFlags().StringVar(
+		&configPath,
+		"config.path",
+		"",
+		`
+YAML config file path.`,
+	)
+
+	var configExpandEnv bool
+	cmd.PersistentFlags().BoolVar(
+		&configExpandEnv,
+		"config.expand-env",
+		false,
+		`
+Whether to expand environment variables in the config file.
+
+This will replaces references to ${VAR} or $VAR with the corresponding
+environment variable. The replacement is case-sensitive.
+
+References to undefined variables will be replaced with an empty string. A
+default value can be given using form ${VAR:default}.`,
+	)
+
+	conf := &config.Config{}
+	conf.RegisterFlags(cmd.PersistentFlags())
+
+	cmd.AddCommand(newStartCommand(conf))
+	cmd.AddCommand(newHTTPCommand(conf))
+	cmd.AddCommand(newPingCommand(conf))
+
+	// Load the configuration but don't yet validate.
+	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if configPath != "" {
+			if err := pikoconfig.Load(configPath, &conf, configExpandEnv); err != nil {
+				fmt.Printf("load config: %s\n", err.Error())
+				os.Exit(1)
+			}
+		}
+
+		if err := conf.Validate(); err != nil {
+			fmt.Printf("config: %s\n", err.Error())
+			os.Exit(1)
+		}
+	}
+
+	return cmd
+}

--- a/cli/agentv2/http.go
+++ b/cli/agentv2/http.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/andydunstall/piko/agentv2/config"
+	"github.com/andydunstall/piko/pkg/log"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func newHTTPCommand(conf *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "http [endpoint] [upstream addr] [flags]",
+		Short: "register a http listener",
+		Long: `Registers a HTTP endpoint with the given endpoint ID and
+forwards incoming connections to your upstream service.
+
+The configured upstream address may be a port, a host and port, or a URL.
+
+Examples:
+  # Register endpoint 'my-endpoint' for forward incoming connections to
+  # localhost:3000.
+  piko agent http my-endpoint 3000
+
+  # Register and forward to 10.26.104.56:3000.
+  piko agent http my-endpoint 10.26.104.56:3000
+
+  # Register and forward to 10.26.104.56:3000 using HTTPS.
+  piko agent http my-endpoint https://10.26.104.56:3000
+`,
+		Args: cobra.ExactArgs(2),
+	}
+
+	var accessLog bool
+	cmd.Flags().BoolVar(
+		&accessLog,
+		"access-log",
+		true,
+		`
+Whether to log all incoming HTTP requests and responses as 'info' logs.`,
+	)
+
+	var logger log.Logger
+
+	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		// Discard any endpoints in the configuration file and use from command
+		// line.
+		conf.Endpoints = nil
+		conf.Endpoints = append(conf.Endpoints, config.EndpointConfig{
+			ID:        args[0],
+			Addr:      args[1],
+			AccessLog: accessLog,
+		})
+
+		var err error
+		logger, err = log.NewLogger(conf.Log.Level, conf.Log.Subsystems)
+		if err != nil {
+			fmt.Printf("failed to setup logger: %s\n", err.Error())
+			os.Exit(1)
+		}
+	}
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		logger.Info(
+			"registered http endpoint",
+			zap.String("id", conf.Endpoints[0].ID),
+			zap.String("addr", conf.Endpoints[0].Addr),
+		)
+	}
+
+	return cmd
+}

--- a/cli/agentv2/ping.go
+++ b/cli/agentv2/ping.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	"github.com/andydunstall/piko/agentv2/config"
+	"github.com/spf13/cobra"
+)
+
+func newPingCommand(_ *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ping [flags]",
+		Short: "ping the piko server",
+		Long: `Connects to and authenticates with the Piko server, then
+measures the round trip latency.
+`,
+	}
+
+	cmd.Run = func(_ *cobra.Command, _ []string) {
+	}
+
+	return cmd
+}

--- a/cli/agentv2/start.go
+++ b/cli/agentv2/start.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/andydunstall/piko/agentv2/config"
+	"github.com/andydunstall/piko/pkg/log"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func newStartCommand(conf *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start [endpoint...] [flags]",
+		Short: "register the configured endpoints",
+		Long: `Registers the configured endpoints with Piko then forwards
+incoming connections for each endpoint to your upstream services.
+
+Examples:
+  # Start all configured endpoints.
+  piko agent start --config.file ./agent.yaml
+
+  # Start only endpoints 'endpoint-1' and 'endpoint-2'.
+  piko agent start endpoint-1 endpoint-2 --config.file ./agent.yaml
+`,
+		Args: cobra.MaximumNArgs(1),
+	}
+
+	var logger log.Logger
+
+	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		var err error
+		logger, err = log.NewLogger(conf.Log.Level, conf.Log.Subsystems)
+		if err != nil {
+			fmt.Printf("failed to setup logger: %s\n", err.Error())
+			os.Exit(1)
+		}
+
+		if len(conf.Endpoints) == 0 {
+			fmt.Printf("no endpoints configured\n")
+			os.Exit(1)
+		}
+
+		// Verify the requested endpoints to start are configured.
+		var endpointIDs []string
+		for _, endpoint := range conf.Endpoints {
+			endpointIDs = append(endpointIDs, endpoint.ID)
+		}
+		for _, arg := range args {
+			if !slices.Contains(endpointIDs, arg) {
+				fmt.Printf("endpoint not found: %s\n", arg)
+				os.Exit(1)
+			}
+		}
+	}
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		for _, endpoint := range conf.Endpoints {
+			if len(args) != 0 && !slices.Contains(args, endpoint.ID) {
+				continue
+			}
+
+			logger.Info(
+				"registered http endpoint",
+				zap.String("id", endpoint.ID),
+				zap.String("addr", endpoint.Addr),
+			)
+		}
+	}
+
+	return cmd
+}

--- a/cli/command.go
+++ b/cli/command.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/andydunstall/piko/cli/agent"
+	agentv2 "github.com/andydunstall/piko/cli/agentv2"
 	"github.com/andydunstall/piko/cli/server"
 	"github.com/andydunstall/piko/cli/status"
 	"github.com/andydunstall/piko/cli/workload"
@@ -46,6 +47,7 @@ Such as to register endpoint 'my-endpoint' that forwards incoming requests to
 	}
 
 	cmd.AddCommand(agent.NewCommand())
+	cmd.AddCommand(agentv2.NewCommand())
 	cmd.AddCommand(server.NewCommand())
 	cmd.AddCommand(status.NewCommand())
 	cmd.AddCommand(workload.NewCommand())

--- a/client/client.go
+++ b/client/client.go
@@ -18,7 +18,7 @@ type Piko struct {
 // Connect establishes a new outbound connection with the Piko server. This
 //
 // This will block until the client can connect.
-//nolint
+// nolint
 func Connect(ctx context.Context, opts ...ConnectOption) (*Piko, error) {
 	return nil, nil
 }
@@ -27,7 +27,7 @@ func Connect(ctx context.Context, opts ...ConnectOption) (*Piko, error) {
 // which accepts incoming connections for that endpoint.
 //
 // [Listener] is a [net.Listener].
-//nolint
+// nolint
 func (p *Piko) Listen(ctx context.Context, endpointID string) (Listener, error) {
 	return nil, nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func Example() {
-	pikoAPIKey := os.Getenv("PIKO_API_KEY")
+	pikoToken := os.Getenv("PIKO_TOKEN")
 
 	// Connect to the Piko server.
 	piko, err := piko.Connect(
 		context.Background(),
-		piko.WithAPIKey(pikoAPIKey),
+		piko.WithToken(pikoToken),
 		piko.WithURL("http://piko.example.com:8001"),
 	)
 	if err != nil {

--- a/client/options.go
+++ b/client/options.go
@@ -1,23 +1,23 @@
 package piko
 
 type connectOptions struct {
-	apiKey string
-	url    string
+	token string
+	url   string
 }
 
 type ConnectOption interface {
 	apply(*connectOptions)
 }
 
-type apiKeyOption string
+type tokenOption string
 
-func (o apiKeyOption) apply(opts *connectOptions) {
-	opts.apiKey = string(o)
+func (o tokenOption) apply(opts *connectOptions) {
+	opts.token = string(o)
 }
 
-// WithAPIKey configures the API key to authenticate the client.
-func WithAPIKey(key string) ConnectOption {
-	return apiKeyOption(key)
+// WithToken configures the API key to authenticate the client.
+func WithToken(key string) ConnectOption {
+	return tokenOption(key)
 }
 
 type urlOption string


### PR DESCRIPTION
Adds the CLI and configuration for the new agent command line tool. This is not yet functional so is hidden from 'piko -h'.