### PR TITLE
agentv2: add endpoint interface

### DIFF
--- a/agentv2/endpoint/endpoint.go
+++ b/agentv2/endpoint/endpoint.go
@@ -1,0 +1,38 @@
+package endpoint
+
+import (
+	"context"
+
+	"github.com/andydunstall/piko/agentv2/config"
+	piko "github.com/andydunstall/piko/client"
+	"github.com/andydunstall/piko/pkg/log"
+	"go.uber.org/zap"
+)
+
+// Endpoint handles connections for the endpoint and forwards traffic the
+// upstream listener.
+type Endpoint struct {
+	id     string
+	logger log.Logger
+}
+
+func NewEndpoint(conf config.EndpointConfig, logger log.Logger) *Endpoint {
+	return &Endpoint{
+		id:     conf.ID,
+		logger: logger.WithSubsystem("endpoint").With(zap.String("endpoint-id", conf.ID)),
+	}
+}
+
+// Serve serves connections on the listener.
+func (e *Endpoint) Serve(_ piko.Listener) error {
+	e.logger.Info("serving endpoint")
+
+	// TODO(andydunstall): Run reverse proxy to accept connections, log
+	// requests and forward to the upstream.
+
+	return nil
+}
+
+func (e *Endpoint) Shutdown(_ context.Context) error {
+	return nil
+}

--- a/cli/agentv2/http.go
+++ b/cli/agentv2/http.go
@@ -1,11 +1,17 @@
 package agent
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/andydunstall/piko/agentv2/config"
+	"github.com/andydunstall/piko/agentv2/endpoint"
+	piko "github.com/andydunstall/piko/client"
 	"github.com/andydunstall/piko/pkg/log"
+	rungroup "github.com/oklog/run"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 )
@@ -63,12 +69,76 @@ Whether to log all incoming HTTP requests and responses as 'info' logs.`,
 	}
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
-		logger.Info(
-			"registered http endpoint",
-			zap.String("id", conf.Endpoints[0].ID),
-			zap.String("addr", conf.Endpoints[0].Addr),
-		)
+		if err := runHTTP(conf, logger); err != nil {
+			logger.Error("failed to run agent", zap.Error(err))
+			os.Exit(1)
+		}
 	}
 
 	return cmd
+}
+
+func runHTTP(conf *config.Config, logger log.Logger) error {
+	logger.Info("starting piko agent")
+
+	// We know there is a single endpoint configured.
+	endpointConfig := conf.Endpoints[0]
+	endpoint := endpoint.NewEndpoint(endpointConfig, logger)
+
+	connectCtx, connectCancel := context.WithTimeout(
+		context.Background(),
+		conf.Connect.Timeout,
+	)
+	defer connectCancel()
+
+	client, err := piko.Connect(connectCtx, piko.WithToken(conf.Token))
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+
+	ln, err := client.Listen(context.Background(), endpointConfig.ID)
+	if err != nil {
+		return fmt.Errorf("listen: %s: %w", endpointConfig.ID, err)
+	}
+
+	var group rungroup.Group
+
+	// Endpoint handler.
+	group.Add(func() error {
+		if err := endpoint.Serve(ln); err != nil {
+			return fmt.Errorf("serve: %w", err)
+		}
+		return nil
+	}, func(error) {
+		shutdownCtx, cancel := context.WithTimeout(
+			context.Background(),
+			conf.GracePeriod,
+		)
+		defer cancel()
+
+		if err := endpoint.Shutdown(shutdownCtx); err != nil {
+			logger.Warn("failed to gracefully shutdown endpoint", zap.Error(err))
+		}
+	})
+
+	// Termination handler.
+	signalCtx, signalCancel := context.WithCancel(context.Background())
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
+	group.Add(func() error {
+		select {
+		case sig := <-signalCh:
+			logger.Info(
+				"received shutdown signal",
+				zap.String("signal", sig.String()),
+			)
+			return nil
+		case <-signalCtx.Done():
+			return nil
+		}
+	}, func(error) {
+		signalCancel()
+	})
+
+	return group.Run()
 }


### PR DESCRIPTION
Adds an 'agent.Endpoint' interface that accepts a Piko listener. The endpoint can then run a reverse proxy to forward requests to the upstream.

Updates the agent command to open a connection to the server, register each endpoint and start the endpoint.