### PR TITLE
tls: add tls support

### DIFF
--- a/cli/agent/command.go
+++ b/cli/agent/command.go
@@ -148,9 +148,15 @@ func run(conf *config.Config, logger log.Logger) error {
 	adminServer := adminserver.NewServer(
 		adminLn,
 		nil,
+		nil,
 		registry,
 		logger,
 	)
+
+	endpointTLSConfig, err := conf.TLS.Load()
+	if err != nil {
+		return fmt.Errorf("tls: %w", err)
+	}
 
 	var group rungroup.Group
 
@@ -179,7 +185,7 @@ func run(conf *config.Config, logger log.Logger) error {
 
 	for _, e := range conf.Endpoints {
 		endpoint := agent.NewEndpoint(
-			e.ID, e.Addr, conf, metrics, logger,
+			e.ID, e.Addr, conf, endpointTLSConfig, metrics, logger,
 		)
 
 		endpointCtx, endpointCancel := context.WithCancel(context.Background())

--- a/docs/manage/configure.md
+++ b/docs/manage/configure.md
@@ -25,17 +25,17 @@ configuration:
 ```
 proxy:
     # The host/port to listen for incoming proxy HTTP requests.
-    # 
+    #
     # If the host is unspecified it defaults to all listeners, such as
     # '--proxy.bind-addr :8000' will listen on '0.0.0.0:8000'.
     bind_addr: :8000
 
     # Proxy listen address to advertise to other nodes in the cluster. This is the
     # address other nodes will used to forward proxy requests.
-    # 
+    #
     # Such as if the listen address is ':8000', the advertised address may be
     # '10.26.104.45:8000' or 'node1.cluster:8000'.
-    # 
+    #
     # By default, if the bind address includes an IP to bind to that will be used.
     # If the bind address does not include an IP (such as ':8000') the nodes
     # private IP will be used, such as a bind address of ':8000' may have an
@@ -48,6 +48,18 @@ proxy:
     # If the upstream does not respond within the given timeout a
     # '504 Gateway Timeout' is returned to the client.
     gateway_timeout: 15s
+
+    tls:
+        # Whether to enable TLS on the listener.
+        #
+        # If enabled must configure the cert and key.
+        enabled: false
+
+        # Path to the PEM encoded certificate file.
+        cert: ""
+
+        # Path to the PEM encoded key file.
+        key: ""
 
     http:
         # The maximum duration for reading the entire request, including the
@@ -71,54 +83,78 @@ proxy:
 
 upstream:
     # The host/port to listen for connections from upstream listeners.
-    # 
+    #
     # If the host is unspecified it defaults to all listeners, such as
     # '--upstream.bind-addr :8001' will listen on '0.0.0.0:8001'.
     bind_addr: :8001
 
     # Upstream listen address to advertise to other nodes in the cluster.
-    # 
+    #
     # Such as if the listen address is ':8001', the advertised address may be
     # '10.26.104.45:8001' or 'node1.cluster:8001'.
-    # 
+    #
     # By default, if the bind address includes an IP to bind to that will be used.
     # If the bind address does not include an IP (such as ':8001') the nodes
     # private IP will be used, such as a bind address of ':8001' may have an
     # advertise address of '10.16.104.14:8001'.
     advertise_addr: ""
 
+    tls:
+        # Whether to enable TLS on the listener.
+        #
+        # If enabled must configure the cert and key.
+        enabled: false
+
+        # Path to the PEM encoded certificate file.
+        cert: ""
+
+        # Path to the PEM encoded key file.
+        key: ""
+
 admin:
     # The host/port to listen for incoming admin connections.
-    # 
+    #
     # If the host is unspecified it defaults to all listeners, such as
     # '--admin.bind-addr :8002' will listen on '0.0.0.0:8002'.
     bind_addr: :8002
 
     # Admin listen address to advertise to other nodes in the cluster. This is the
     # address other nodes will used to forward admin requests.
-    # 
+    #
     # Such as if the listen address is ':8002', the advertised address may be
     # '10.26.104.45:8002' or 'node1.cluster:8002'.
-    # 
+    #
     # By default, if the bind address includes an IP to bind to that will be used.
     # If the bind address does not include an IP (such as ':8002') the nodes
     # private IP will be used, such as a bind address of ':8002' may have an
     # advertise address of '10.26.104.14:8002'.
     advertise_addr: ""
 
+    tls:
+        # Whether to enable TLS on the listener.
+        #
+        # If enabled must configure the cert and key.
+        enabled: false
+
+        # Path to the PEM encoded certificate file.
+        cert: ""
+
+        # Path to the PEM encoded key file.
+        key: ""
+
 gossip:
     # The host/port to listen for inter-node gossip traffic.
-    # 
+    #
     # If the host is unspecified it defaults to all listeners, such as
     # '--gossip.bind-addr :8003' will listen on '0.0.0.0:8003'.
     bind_addr: :8003
 
     # Gossip listen address to advertise to other nodes in the cluster. This is the
     # address other nodes will used to gossip with the node.
-    # 
+    #
     # Such as if the listen address is ':8003', the advertised address may be
     # '10.26.104.45:8003' or 'node1.cluster:8003'.
-    # 
+    #
     # By default, if the bind address includes an IP to bind to that will be used.
     # If the bind address does not include an IP (such as ':8003') the nodes
     # private IP will be used, such as a bind address of ':8003' may have an
@@ -127,29 +163,29 @@ gossip:
 
 cluster:
     # A unique identifier for the node in the cluster.
-    # 
+    #
     # By default a random ID will be generated for the node.
     node_id: ""
 
     # A prefix for the node ID.
-    # 
+    #
     # Piko will generate a unique random identifier for the node and append it to
     # the given prefix.
-    # 
+    #
     # Such as you could use the node or pod  name as a prefix, then add a unique
     # identifier to ensure the node ID is unique across restarts.
     node_id_prefix: ""
 
     # A list of addresses of members in the cluster to join.
-    # 
+    #
     # This may be either addresses of specific nodes, such as
     # '--cluster.join 10.26.104.14,10.26.104.75', or a domain that resolves to
     # the addresses of the nodes in the cluster (e.g. a Kubernetes headless
     # service), such as '--cluster.join piko.prod-piko-ns'.
-    # 
+    #
     # Each address must include the host, and may optionally include a port. If no
     # port is given, the gossip port of this node is used.
-    # 
+    #
     # Note each node propagates membership information to the other known nodes,
     # so the initial set of configured members only needs to be a subset of nodes.
     join: []
@@ -182,16 +218,16 @@ auth:
 
 log:
     # Minimum log level to output.
-    # 
+    #
     # The available levels are 'debug', 'info', 'warn' and 'error'.
     level: info
 
     # Each log has a 'subsystem' field where the log occured.
-    # 
+    #
     # '--log.subsystems' enables all log levels for those given subsystems. This
     # can be useful to debug a particular subsystem without having to enable all
     # debug logs.
-    # 
+    #
     # Such as you can enable 'gossip' logs with '--log.subsystems gossip'.
     subsystems: []
 
@@ -273,23 +309,23 @@ endpoints:
 
 server:
     # Piko server URL.
-    # 
+    #
     # The listener will add path /piko/v1/listener/:endpoint_id to the given URL,
     # so if you include a path it will be used as a prefix.
-    # 
+    #
     # Note Piko connects to the server with WebSockets, so will replace http/https
     # with ws/wss (you can configure either).
     url: http://localhost:8001
 
     # Heartbeat interval.
-    # 
+    #
     # To verify the connection to the server is ok, the listener sends a
     # heartbeat to the upstream at the '--server.heartbeat-interval'
     # interval, with a timeout of '--server.heartbeat-timeout'.`,
     heartbeat_interval: 10s
 
     # Heartbeat timeout.
-    # 
+    #
     # To verify the connection to the server is ok, the listener sends a
     # heartbeat to the upstream at the '--server.heartbeat-interval'
     heartbeat_timeout: 10s
@@ -300,33 +336,40 @@ auth:
 
 forwarder:
     # Forwarder timeout.
-    # 
+    #
     # This is the timeout between a listener receiving a request from Piko then
     # forwarding it to the configured forward address, and receiving a response.
-    # 
+    #
     # If the upstream does not respond within the given timeout a
     # '504 Gateway Timeout' is returned to the client.
     timeout: 10s
 
+tls:
+    # A path to a certificate PEM file containing root certificiate authorities
+    # to validate the TLS connection to the Piko server.
+    #
+    # Defaults to using the host root CAs.`,
+    root_cas: ""
+
 admin:
     # The host/port to listen for incoming admin connections.
-    # 
+    #
     # If the host is unspecified it defaults to all listeners, such as
     # '--admin.bind-addr :9000' will listen on '0.0.0.0:9000'
     bind_addr: :9000
 
 log:
     # Minimum log level to output.
-    # 
+    #
     # The available levels are 'debug', 'info', 'warn' and 'error'.
     level: info
 
     # Each log has a 'subsystem' field where the log occured.
-    # 
+    #
     # '--log.subsystems' enables all log levels for those given subsystems. This
     # can be useful to debug a particular subsystem without having to enable all
     # debug logs.
-    # 
+    #
     # Such as you can enable 'gossip' logs with '--log.subsystems gossip'.
     subsystems: []
 ```

--- a/pkg/testutil/tls.go
+++ b/pkg/testutil/tls.go
@@ -1,0 +1,110 @@
+package testutil
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+// LocalTLSServerCert creates a root CA and server TLS certificate.
+func LocalTLSServerCert() (*x509.CertPool, tls.Certificate, error) {
+	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("generate key: %w", err)
+	}
+	rootTemplate, err := certTemplate()
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("root cert template: %w", err)
+	}
+	// CA certificate.
+	rootTemplate.IsCA = true
+	rootTemplate.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature
+	rootTemplate.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+
+	_, rootCert, err := cert(
+		rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey,
+	)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("root cert: %w", err)
+	}
+
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("generate key: %w", err)
+	}
+	serverTemplate, err := certTemplate()
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("server cert template: %w", err)
+	}
+	serverTemplate.KeyUsage = x509.KeyUsageDigitalSignature
+	serverTemplate.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	serverTemplate.IPAddresses = []net.IP{net.IPv4(127, 0, 0, 1)}
+
+	// Sign the cert using the root CA.
+	serverCertDER, _, err := cert(
+		serverTemplate, rootCert, &serverKey.PublicKey, rootKey,
+	)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("server cert: %w", err)
+	}
+
+	rootCACertPool := x509.NewCertPool()
+	rootCACertPool.AddCert(rootCert)
+
+	serverCertPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE", Bytes: serverCertDER,
+	})
+	serverKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey),
+	})
+
+	serverTLSCert, err := tls.X509KeyPair(serverCertPEM, serverKeyPEM)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("server key pair: %w", err)
+	}
+
+	return rootCACertPool, serverTLSCert, nil
+}
+
+func cert(
+	template *x509.Certificate,
+	parent *x509.Certificate,
+	publicKey interface{},
+	parentPrivateKey interface{},
+) ([]byte, *x509.Certificate, error) {
+	certDER, err := x509.CreateCertificate(
+		rand.Reader, template, parent, publicKey, parentPrivateKey,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create cert: %w", err)
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse cert: %w", err)
+	}
+	return certDER, cert, nil
+}
+
+func certTemplate() (*x509.Certificate, error) {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, fmt.Errorf("generate serial: %w", err)
+	}
+
+	return &x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{Organization: []string{"Piko"}},
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour * 24 * 30),
+		BasicConstraintsValid: true,
+	}, nil
+}

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -16,11 +16,16 @@ type UpstreamConfig struct {
 
 	// AdvertiseAddr is the address to advertise to other nodes.
 	AdvertiseAddr string `json:"advertise_addr" yaml:"advertise_addr"`
+
+	TLS TLSConfig `json:"tls" yaml:"tls"`
 }
 
 func (c *UpstreamConfig) Validate() error {
 	if c.BindAddr == "" {
 		return fmt.Errorf("missing bind addr")
+	}
+	if err := c.TLS.Validate(); err != nil {
+		return fmt.Errorf("tls: %w", err)
 	}
 	return nil
 }
@@ -31,11 +36,16 @@ type AdminConfig struct {
 
 	// AdvertiseAddr is the address to advertise to other nodes.
 	AdvertiseAddr string `json:"advertise_addr" yaml:"advertise_addr"`
+
+	TLS TLSConfig `json:"tls" yaml:"tls"`
 }
 
 func (c *AdminConfig) Validate() error {
 	if c.BindAddr == "" {
 		return fmt.Errorf("missing bind addr")
+	}
+	if err := c.TLS.Validate(); err != nil {
+		return fmt.Errorf("tls: %w", err)
 	}
 	return nil
 }
@@ -137,6 +147,7 @@ If the bind address does not include an IP (such as ':8001') the nodes
 private IP will be used, such as a bind address of ':8001' may have an
 advertise address of '10.16.104.14:8001'.`,
 	)
+	c.Upstream.TLS.RegisterFlags(fs, "upstream")
 
 	fs.StringVar(
 		&c.Admin.BindAddr,
@@ -164,6 +175,7 @@ If the bind address does not include an IP (such as ':8002') the nodes
 private IP will be used, such as a bind address of ':8002' may have an
 advertise address of '10.26.104.14:8002'.`,
 	)
+	c.Admin.TLS.RegisterFlags(fs, "admin")
 
 	fs.StringVar(
 		&c.Cluster.NodeID,

--- a/server/config/proxy.go
+++ b/server/config/proxy.go
@@ -92,6 +92,8 @@ type ProxyConfig struct {
 	GatewayTimeout time.Duration `json:"gateway_timeout" yaml:"gateway_timeout"`
 
 	HTTP ProxyHTTPConfig `json:"http" yaml:"http"`
+
+	TLS TLSConfig `json:"tls" yaml:"tls"`
 }
 
 func (c *ProxyConfig) Validate() error {
@@ -100,6 +102,9 @@ func (c *ProxyConfig) Validate() error {
 	}
 	if c.GatewayTimeout == 0 {
 		return fmt.Errorf("missing gateway timeout")
+	}
+	if err := c.TLS.Validate(); err != nil {
+		return fmt.Errorf("tls: %w", err)
 	}
 
 	return nil
@@ -144,5 +149,6 @@ If the upstream does not respond within the given timeout a
 '504 Gateway Timeout' is returned to the client.`,
 	)
 
+	c.TLS.RegisterFlags(fs, "proxy")
 	c.HTTP.RegisterFlags(fs, "proxy")
 }

--- a/server/config/tls.go
+++ b/server/config/tls.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+type TLSConfig struct {
+	Enabled bool   `json:"enabled" yaml:"enabled"`
+	Cert    string `json:"cert" yaml:"cert"`
+	Key     string `json:"key" yaml:"key"`
+}
+
+func (c *TLSConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+
+	if c.Cert == "" {
+		return fmt.Errorf("missing cert")
+	}
+	if c.Key == "" {
+		return fmt.Errorf("missing key")
+	}
+	return nil
+}
+
+func (c *TLSConfig) RegisterFlags(fs *pflag.FlagSet, prefix string) {
+	prefix += ".tls."
+
+	fs.BoolVar(
+		&c.Enabled,
+		prefix+"enabled",
+		false,
+		`
+Whether to enable TLS on the listener.
+
+If enabled must configure the cert and key.`,
+	)
+	fs.StringVar(
+		&c.Cert,
+		prefix+"cert",
+		"",
+		`
+Path to the PEM encoded certificate file.`,
+	)
+	fs.StringVar(
+		&c.Key,
+		prefix+"key",
+		"",
+		`
+Path to the PEM encoded key file.`,
+	)
+}
+
+func (c *TLSConfig) Load() (*tls.Config, error) {
+	if !c.Enabled {
+		return nil, nil
+	}
+
+	tlsConfig := &tls.Config{}
+	cert, err := tls.LoadX509KeyPair(c.Cert, c.Key)
+	if err != nil {
+		return nil, fmt.Errorf("load key pair: %w", err)
+	}
+	tlsConfig.Certificates = []tls.Certificate{cert}
+
+	return tlsConfig, nil
+}

--- a/server/server/upstream/server_integration_test.go
+++ b/server/server/upstream/server_integration_test.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/andydunstall/piko/pkg/conn/websocket"
 	"github.com/andydunstall/piko/pkg/log"
 	"github.com/andydunstall/piko/pkg/rpc"
+	"github.com/andydunstall/piko/pkg/testutil"
 	"github.com/andydunstall/piko/server/auth"
 	proxy "github.com/andydunstall/piko/server/proxy"
 	"github.com/stretchr/testify/assert"
@@ -58,6 +60,7 @@ func TestServer_AddConn(t *testing.T) {
 			upstreamLn,
 			proxy,
 			nil,
+			nil,
 			log.NewNopLogger(),
 		)
 		go func() {
@@ -101,6 +104,7 @@ func TestServer_AddConn(t *testing.T) {
 			upstreamLn,
 			proxy,
 			verifier,
+			nil,
 			log.NewNopLogger(),
 		)
 		go func() {
@@ -145,6 +149,7 @@ func TestServer_AddConn(t *testing.T) {
 			upstreamLn,
 			proxy,
 			verifier,
+			nil,
 			log.NewNopLogger(),
 		)
 		go func() {
@@ -188,6 +193,7 @@ func TestServer_AddConn(t *testing.T) {
 			upstreamLn,
 			nil,
 			verifier,
+			nil,
 			log.NewNopLogger(),
 		)
 		go func() {
@@ -218,6 +224,7 @@ func TestServer_AddConn(t *testing.T) {
 			upstreamLn,
 			nil,
 			verifier,
+			nil,
 			log.NewNopLogger(),
 		)
 		go func() {
@@ -232,5 +239,69 @@ func TestServer_AddConn(t *testing.T) {
 		_, err = websocket.Dial(context.TODO(), url, websocket.WithToken("123"))
 		require.Error(t, err)
 	})
+}
 
+func TestServer_TLS(t *testing.T) {
+	rootCAPool, cert, err := testutil.LocalTLSServerCert()
+	require.NoError(t, err)
+
+	upstreamLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	tlsConfig := &tls.Config{}
+	tlsConfig.Certificates = []tls.Certificate{cert}
+
+	proxy := newFakeProxy()
+	upstreamServer := NewServer(
+		upstreamLn,
+		proxy,
+		nil,
+		tlsConfig,
+		log.NewNopLogger(),
+	)
+	go func() {
+		require.NoError(t, upstreamServer.Serve())
+	}()
+	defer upstreamServer.Shutdown(context.TODO())
+
+	t.Run("wss ok", func(t *testing.T) {
+		url := fmt.Sprintf(
+			"wss://%s/piko/v1/listener/my-endpoint",
+			upstreamLn.Addr().String(),
+		)
+		clientTLSConfig := &tls.Config{
+			RootCAs: rootCAPool,
+		}
+		conn, err := websocket.Dial(
+			context.TODO(), url, websocket.WithTLSConfig(clientTLSConfig),
+		)
+		require.NoError(t, err)
+
+		// Add client stream and ensure upstream added to proxy.
+		rpcServer := newRPCServer()
+		stream := rpc.NewStream(conn, rpcServer.Handler(), log.NewNopLogger())
+		assert.Equal(t, "my-endpoint", <-proxy.addUpstreamCh)
+
+		// Close client stream and ensure upstream removed from proxy.
+		stream.Close()
+		assert.Equal(t, "my-endpoint", <-proxy.removeUpstreamCh)
+	})
+
+	t.Run("wss bad ca", func(t *testing.T) {
+		url := fmt.Sprintf(
+			"wss://%s/piko/v1/listener/my-endpoint",
+			upstreamLn.Addr().String(),
+		)
+		_, err := websocket.Dial(context.TODO(), url)
+		require.ErrorContains(t, err, "certificate signed by unknown authority")
+	})
+
+	t.Run("ws", func(t *testing.T) {
+		url := fmt.Sprintf(
+			"ws://%s/piko/v1/listener/my-endpoint",
+			upstreamLn.Addr().String(),
+		)
+		_, err := websocket.Dial(context.TODO(), url)
+		require.ErrorContains(t, err, "bad handshake")
+	})
 }

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -80,7 +80,7 @@ func TestProxy(t *testing.T) {
 
 	agentConf := defaultAgentConfig(serverConf.Upstream.AdvertiseAddr)
 	endpoint := agent.NewEndpoint(
-		"my-endpoint", upstream.Addr(), agentConf, agent.NewMetrics(), log.NewNopLogger(),
+		"my-endpoint", upstream.Addr(), agentConf, nil, agent.NewMetrics(), log.NewNopLogger(),
 	)
 	go func() {
 		assert.NoError(t, endpoint.Run(ctx))
@@ -151,7 +151,7 @@ func TestProxy_Authenticated(t *testing.T) {
 	agentConf := defaultAgentConfig(serverConf.Upstream.AdvertiseAddr)
 	agentConf.Auth.APIKey = apiKey
 	endpoint := agent.NewEndpoint(
-		"my-endpoint", upstream.Addr(), agentConf, agent.NewMetrics(), log.NewNopLogger(),
+		"my-endpoint", upstream.Addr(), agentConf, nil, agent.NewMetrics(), log.NewNopLogger(),
 	)
 	go func() {
 		assert.NoError(t, endpoint.Run(ctx))

--- a/workload/upstream/upstream.go
+++ b/workload/upstream/upstream.go
@@ -86,7 +86,7 @@ func (u *Upstream) Run(ctx context.Context) error {
 
 	agentConf := agentConfig(u.serverURL)
 	endpoint := agent.NewEndpoint(
-		u.endpointID, server.Addr(), agentConf, agent.NewMetrics(), log.NewNopLogger(),
+		u.endpointID, server.Addr(), agentConf, nil, agent.NewMetrics(), log.NewNopLogger(),
 	)
 	if err = endpoint.Run(ctx); err != nil {
 		return fmt.Errorf("endpoint: %w", err)


### PR DESCRIPTION
Adds TLS support to both the Piko server and agent.

Each port on the server has independent TLS configuration, where TLS can be enabled and the key/cert configured.

The agent has configuration for configuring the root CA cert (which overrides using the hosts root CA).

See discussion https://github.com/andydunstall/piko/discussions/51 for context.