### PR TITLE
serverv2: add reverse proxy to forward requests to upstream

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -68,7 +68,10 @@ func (p *Piko) Listen(_ context.Context, endpointID string) (Listener, error) {
 		return nil, fmt.Errorf("rpc: %w", err)
 	}
 
-	return &listener{}, nil
+	return &listener{
+		// TODO(andydunstall): For now only support a single endpoint.
+		sess: p.sess,
+	}, nil
 }
 
 // Close closes the connection to Piko and any open listeners.

--- a/client/listener.go
+++ b/client/listener.go
@@ -1,6 +1,10 @@
 package piko
 
-import "net"
+import (
+	"net"
+
+	"golang.ngrok.com/muxado/v2"
+)
 
 // Listener is a [net.Listener] that accepts incoming connections for endpoints
 // registered with the server by the client.
@@ -15,10 +19,15 @@ type Listener interface {
 }
 
 type listener struct {
+	sess *muxado.Heartbeat
 }
 
 func (l *listener) Accept() (net.Conn, error) {
-	return nil, nil
+	stream, err := l.sess.AcceptTypedStream()
+	if err != nil {
+		return nil, err
+	}
+	return stream, nil
 }
 
 func (l *listener) Close() error {

--- a/pkg/protocol/message.go
+++ b/pkg/protocol/message.go
@@ -6,6 +6,7 @@ type RPCType muxado.StreamType
 
 const (
 	RPCTypeListen RPCType = iota + 1
+	RPCTypeProxy
 )
 
 type ListenRequest struct {

--- a/serverv2/server/proxy/server.go
+++ b/serverv2/server/proxy/server.go
@@ -1,0 +1,66 @@
+package proxy
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"github.com/andydunstall/piko/pkg/log"
+	"github.com/andydunstall/piko/serverv2/upstream"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type Server struct {
+	server *http.Server
+
+	logger log.Logger
+}
+
+func NewServer(manager *upstream.Manager, logger log.Logger) *Server {
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			// TODO(andydunstall): Currently connecting to any available
+			// upstream.
+			return manager.Dial()
+		},
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	// TODO(andydunstall): Configure timeouts, access log, ...
+	proxy := &httputil.ReverseProxy{
+		Transport: transport,
+		Rewrite: func(r *httputil.ProxyRequest) {
+			u, _ := url.Parse("http://localhost:9999")
+			r.SetURL(u)
+		},
+		ErrorLog: logger.StdLogger(zapcore.WarnLevel),
+	}
+	return &Server{
+		server: &http.Server{
+			Handler:  proxy,
+			ErrorLog: logger.StdLogger(zapcore.WarnLevel),
+		},
+		logger: logger,
+	}
+}
+
+// Serve serves connections on the listener.
+func (s *Server) Serve(ln net.Listener) error {
+	s.logger.Info(
+		"starting http server",
+		zap.String("addr", ln.Addr().String()),
+	)
+	return s.server.Serve(ln)
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
+}

--- a/serverv2/upstream/manager.go
+++ b/serverv2/upstream/manager.go
@@ -1,0 +1,55 @@
+package upstream
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/andydunstall/piko/pkg/protocol"
+	"golang.ngrok.com/muxado/v2"
+)
+
+// Manager manages the set of local upsteam services.
+//
+// TODO(andydunstall): Only supports a single upstream.
+type Manager struct {
+	upstream *Upstream
+
+	mu sync.Mutex
+}
+
+func NewManager() *Manager {
+	return &Manager{}
+}
+
+func (m *Manager) Add(upstream *Upstream) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.upstream = upstream
+}
+
+func (m *Manager) Remove(_ *Upstream) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.upstream = nil
+}
+
+func (m *Manager) Dial() (net.Conn, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.upstream == nil {
+		return nil, fmt.Errorf("not found")
+	}
+
+	stream, err := m.upstream.Sess.OpenTypedStream(
+		muxado.StreamType(protocol.RPCTypeProxy),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return stream, nil
+}

--- a/serverv2/upstream/upstream.go
+++ b/serverv2/upstream/upstream.go
@@ -1,0 +1,7 @@
+package upstream
+
+import "golang.ngrok.com/muxado/v2"
+
+type Upstream struct {
+	Sess muxado.TypedStreamSession
+}


### PR DESCRIPTION
Adds a simple serverv2 proof of concept. The server runs a HTTP reverse proxy, and to dial an upstream it looks for an existing upstream muxado connection, then creates a new stream on that existing connection.