### PR TITLE
serverv2: load balance among connected upstreams

### DIFF
--- a/serverv2/upstream/manager.go
+++ b/serverv2/upstream/manager.go
@@ -1,57 +1,83 @@
 package upstream
 
 import (
-	"fmt"
-	"net"
 	"sync"
 )
 
+// localLoadBalancer load balances requests among upstreams connected to
+// the local node.
+type localLoadBalancer struct {
+	upstreams []Upstream
+	nextIndex int
+}
+
+func (lb *localLoadBalancer) Add(u Upstream) {
+	lb.upstreams = append(lb.upstreams, u)
+}
+
+func (lb *localLoadBalancer) Remove(u Upstream) bool {
+	for i := 0; i != len(lb.upstreams); i++ {
+		if lb.upstreams[i] != u {
+			continue
+		}
+		lb.upstreams = append(lb.upstreams[:i], lb.upstreams[i+1:]...)
+		if len(lb.upstreams) == 0 {
+			return true
+		}
+		lb.nextIndex %= len(lb.upstreams)
+		return false
+	}
+	return len(lb.upstreams) == 0
+}
+
+func (lb *localLoadBalancer) Next() Upstream {
+	if len(lb.upstreams) == 0 {
+		return nil
+	}
+
+	u := lb.upstreams[lb.nextIndex]
+	lb.nextIndex++
+	lb.nextIndex %= len(lb.upstreams)
+	return u
+}
+
 // Manager manages the set of local upsteam services.
 type Manager struct {
-	upstreams map[string][]Upstream
+	localLoadBalancers map[string]*localLoadBalancer
 
 	mu sync.Mutex
 }
 
 func NewManager() *Manager {
 	return &Manager{
-		upstreams: make(map[string][]Upstream),
+		localLoadBalancers: make(map[string]*localLoadBalancer),
 	}
 }
 
-func (m *Manager) Add(upstream Upstream) {
+func (m *Manager) Add(u Upstream) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.upstreams[upstream.EndpointID()] = append(
-		m.upstreams[upstream.EndpointID()], upstream,
-	)
-}
-
-func (m *Manager) Remove(upstream Upstream) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	var upstreams []Upstream
-	for _, u := range m.upstreams[upstream.EndpointID()] {
-		if u != upstream {
-			upstreams = append(upstreams, u)
-		}
+	lb, ok := m.localLoadBalancers[u.EndpointID()]
+	if !ok {
+		lb = &localLoadBalancer{}
 	}
 
-	m.upstreams[upstream.EndpointID()] = upstreams
+	lb.Add(u)
+	m.localLoadBalancers[u.EndpointID()] = lb
 }
 
-func (m *Manager) Dial(endpointID string) (net.Conn, error) {
+func (m *Manager) Remove(u Upstream) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	upstreams, ok := m.upstreams[endpointID]
-	if !ok || len(upstreams) == 0 {
-		return nil, fmt.Errorf("not found")
+	lb, ok := m.localLoadBalancers[u.EndpointID()]
+	if !ok {
+		return
 	}
-
-	return upstreams[0].Dial()
+	if lb.Remove(u) {
+		delete(m.localLoadBalancers, u.EndpointID())
+	}
 }
 
 func (m *Manager) Select(endpointID string, _ bool) (Upstream, bool) {
@@ -61,9 +87,9 @@ func (m *Manager) Select(endpointID string, _ bool) (Upstream, bool) {
 	// TODO(andydunstall): If allowForward can select from another node, where
 	// Dial is just TCP
 
-	upstreams, ok := m.upstreams[endpointID]
-	if !ok || len(upstreams) == 0 {
+	lb, ok := m.localLoadBalancers[endpointID]
+	if !ok {
 		return nil, false
 	}
-	return upstreams[0], true
+	return lb.Next(), true
 }

--- a/serverv2/upstream/manager_test.go
+++ b/serverv2/upstream/manager_test.go
@@ -1,0 +1,56 @@
+package upstream
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeUpstream struct {
+	endpointID string
+}
+
+func (u *fakeUpstream) EndpointID() string {
+	return u.endpointID
+}
+
+func (u *fakeUpstream) Dial() (net.Conn, error) {
+	return nil, nil
+}
+
+func TestLocalLoadBalancer(t *testing.T) {
+	lb := &localLoadBalancer{}
+
+	assert.Nil(t, lb.Next())
+
+	u1 := &fakeUpstream{endpointID: "1"}
+	lb.Add(u1)
+	assert.Equal(t, "1", lb.Next().EndpointID())
+
+	u2 := &fakeUpstream{endpointID: "2"}
+	u3 := &fakeUpstream{endpointID: "3"}
+	u4 := &fakeUpstream{endpointID: "4"}
+	lb.Add(u2)
+	lb.Add(u3)
+	lb.Add(u4)
+
+	assert.Equal(t, "1", lb.Next().EndpointID())
+	assert.Equal(t, "2", lb.Next().EndpointID())
+	assert.Equal(t, "3", lb.Next().EndpointID())
+	assert.Equal(t, "4", lb.Next().EndpointID())
+	assert.Equal(t, "1", lb.Next().EndpointID())
+	assert.Equal(t, "2", lb.Next().EndpointID())
+	assert.Equal(t, "3", lb.Next().EndpointID())
+
+	assert.False(t, lb.Remove(u2))
+	assert.False(t, lb.Remove(u3))
+	assert.Equal(t, "1", lb.Next().EndpointID())
+	assert.Equal(t, "4", lb.Next().EndpointID())
+	assert.Equal(t, "1", lb.Next().EndpointID())
+
+	assert.False(t, lb.Remove(u1))
+	assert.True(t, lb.Remove(u4))
+
+	assert.Nil(t, lb.Next())
+}


### PR DESCRIPTION
Load balances incoming proxy requests among connected upstreams in a round-robin fashion.