### PR TITLE
admin: add request forwarding

### DIFF
--- a/cli/server/command.go
+++ b/cli/server/command.go
@@ -353,6 +353,7 @@ func runServer(conf *config.Config, logger log.Logger) error {
 		return fmt.Errorf("admin tls: %w", err)
 	}
 	adminServer := admin.NewServer(
+		clusterState,
 		registry,
 		adminTLSConfig,
 		logger,

--- a/cli/server/status/command.go
+++ b/cli/server/status/command.go
@@ -22,11 +22,14 @@ can be used to answer questions such as:
 * What cluster state does this node know?
 * What is the gossip state of each known node?
 
-See 'status --help' for the availale commands.
+See 'piko server status --help' for the available commands.
 
 Examples:
   # Inspect the known nodes in the cluster.
   piko server status cluster nodes
+
+  # Inspect the known nodes by node cv6cdyo.
+  piko server status cluster nodes --forward cv6cdyo
 `,
 	}
 
@@ -43,6 +46,7 @@ Examples:
 
 		url, _ := url.Parse(conf.Server.URL)
 		c.SetURL(url)
+		c.SetForward(conf.Forward)
 	}
 
 	cmd.AddCommand(newClusterCommand(c))

--- a/server/admin/reverseproxy.go
+++ b/server/admin/reverseproxy.go
@@ -1,0 +1,77 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httputil"
+	"time"
+
+	"github.com/andydunstall/piko/pkg/log"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type contextKey int
+
+const (
+	hostContextKey contextKey = iota
+)
+
+type ReverseProxy struct {
+	proxy *httputil.ReverseProxy
+
+	logger log.Logger
+}
+
+func NewReverseProxy(logger log.Logger) *ReverseProxy {
+	rp := &ReverseProxy{
+		logger: logger,
+	}
+
+	rp.proxy = &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = "http"
+			req.URL.Host = req.Context().Value(hostContextKey).(string)
+		},
+		ErrorLog:     logger.StdLogger(zapcore.WarnLevel),
+		ErrorHandler: rp.errorHandler,
+	}
+
+	return rp
+}
+
+func (p *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), time.Second*15)
+	defer cancel()
+
+	r = r.WithContext(ctx)
+
+	p.proxy.ServeHTTP(w, r)
+}
+
+func (p *ReverseProxy) errorHandler(w http.ResponseWriter, _ *http.Request, err error) {
+	p.logger.Warn("proxy request", zap.Error(err))
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		_ = errorResponse(w, http.StatusGatewayTimeout, "upstream timeout")
+		return
+	}
+	_ = errorResponse(w, http.StatusBadGateway, "upstream unreachable")
+}
+
+type errorMessage struct {
+	Error string `json:"error"`
+}
+
+func errorResponse(w http.ResponseWriter, statusCode int, message string) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(statusCode)
+
+	m := &errorMessage{
+		Error: message,
+	}
+	return json.NewEncoder(w).Encode(m)
+}

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/andydunstall/piko/pkg/log"
 	"github.com/andydunstall/piko/pkg/testutil"
+	"github.com/andydunstall/piko/server/cluster"
 	"github.com/andydunstall/piko/server/status"
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
@@ -36,6 +37,7 @@ func TestServer_AdminRoutes(t *testing.T) {
 	require.NoError(t, err)
 
 	s := NewServer(
+		nil,
 		prometheus.NewRegistry(),
 		nil,
 		log.NewNopLogger(),
@@ -69,6 +71,7 @@ func TestServer_StatusRoutes(t *testing.T) {
 	require.NoError(t, err)
 
 	s := NewServer(
+		nil,
 		prometheus.NewRegistry(),
 		nil,
 		log.NewNopLogger(),
@@ -104,6 +107,79 @@ func TestServer_StatusRoutes(t *testing.T) {
 	})
 }
 
+// TestServer_Forward tests forwarding an admin request to another node
+// in the cluster.
+func TestServer_Forward(t *testing.T) {
+	ln1, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	state1 := cluster.NewState(&cluster.Node{
+		ID:        "node-1",
+		AdminAddr: ln1.Addr().String(),
+	}, log.NewNopLogger())
+
+	s1 := NewServer(
+		state1,
+		prometheus.NewRegistry(),
+		nil,
+		log.NewNopLogger(),
+	)
+	// Note only node 1 registers the status route.
+	s1.AddStatus("/mystatus", &fakeStatus{})
+
+	go func() {
+		require.NoError(t, s1.Serve(ln1))
+	}()
+	defer s1.Shutdown(context.TODO())
+
+	ln2, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	state2 := cluster.NewState(&cluster.Node{
+		ID:        "node-2",
+		AdminAddr: ln2.Addr().String(),
+	}, log.NewNopLogger())
+	state2.AddNode(&cluster.Node{
+		ID:        "node-1",
+		AdminAddr: ln1.Addr().String(),
+	})
+
+	s2 := NewServer(
+		state2,
+		prometheus.NewRegistry(),
+		nil,
+		log.NewNopLogger(),
+	)
+
+	go func() {
+		require.NoError(t, s2.Serve(ln2))
+	}()
+	defer s2.Shutdown(context.TODO())
+
+	t.Run("forward ok", func(t *testing.T) {
+		url := fmt.Sprintf("http://%s/status/mystatus/foo?forward=node-1", ln2.Addr().String())
+		resp, err := http.Get(url)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		buf := new(bytes.Buffer)
+		//nolint
+		buf.ReadFrom(resp.Body)
+		assert.Equal(t, []byte("foo"), buf.Bytes())
+	})
+
+	t.Run("forward not found", func(t *testing.T) {
+		url := fmt.Sprintf("http://%s/status/mystatus/foo?forward=node-3", ln2.Addr().String())
+		resp, err := http.Get(url)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}
+
 func TestServer_TLS(t *testing.T) {
 	rootCAPool, cert, err := testutil.LocalTLSServerCert()
 	require.NoError(t, err)
@@ -115,6 +191,7 @@ func TestServer_TLS(t *testing.T) {
 	tlsConfig.Certificates = []tls.Certificate{cert}
 
 	s := NewServer(
+		nil,
 		prometheus.NewRegistry(),
 		tlsConfig,
 		log.NewNopLogger(),

--- a/server/status/client/client.go
+++ b/server/status/client/client.go
@@ -13,6 +13,8 @@ type Client struct {
 	httpClient *http.Client
 
 	url *url.URL
+
+	forward string
 }
 
 func NewClient(url *url.URL) *Client {
@@ -28,9 +30,17 @@ func (c *Client) SetURL(url *url.URL) {
 	c.url = url
 }
 
+func (c *Client) SetForward(forward string) {
+	c.forward = forward
+}
+
 func (c *Client) Request(path string) (io.ReadCloser, error) {
 	url := new(url.URL)
 	*url = *c.url
+
+	if c.forward != "" {
+		url.RawQuery = "forward=" + c.forward
+	}
 
 	url.Path = fspath.Join(url.Path, path)
 

--- a/server/status/config/config.go
+++ b/server/status/config/config.go
@@ -24,6 +24,8 @@ func (c *ServerConfig) Validate() error {
 
 type Config struct {
 	Server ServerConfig `json:"server"`
+
+	Forward string `json:"forward"`
 }
 
 func (c *Config) Validate() error {
@@ -40,6 +42,16 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 		"http://localhost:8002",
 		`
 Piko server URL. This URL should point to the server admin port.
+`,
+	)
+
+	fs.StringVar(
+		&c.Forward,
+		"forward",
+		"",
+		`
+Node ID to forward the request to. This can be useful when all nodes are behind
+a load balancer and you want to inspect the status of a particular node.
 `,
 	)
 }


### PR DESCRIPTION
Adds support for forwarding requests to the admin API to other nodes in the cluster by node ID.

This can be useful when the cluster is hosted behind a load balancer and you want to inspect a particular node by node ID.