### PR TITLE
status: add upstream endpoints status command

### DIFF
--- a/cli/server/command.go
+++ b/cli/server/command.go
@@ -358,6 +358,7 @@ func runServer(conf *config.Config, logger log.Logger) error {
 		adminTLSConfig,
 		logger,
 	)
+	adminServer.AddStatus("/upstream", upstream.NewStatus(upstreams))
 	adminServer.AddStatus("/cluster", cluster.NewStatus(clusterState))
 	adminServer.AddStatus("/gossip", gossip.NewStatus(gossiper))
 

--- a/cli/server/status/command.go
+++ b/cli/server/status/command.go
@@ -49,6 +49,7 @@ Examples:
 		c.SetForward(conf.Forward)
 	}
 
+	cmd.AddCommand(newUpstreamCommand(c))
 	cmd.AddCommand(newClusterCommand(c))
 	cmd.AddCommand(newGossipCommand(c))
 

--- a/cli/server/status/upstream.go
+++ b/cli/server/status/upstream.go
@@ -1,0 +1,54 @@
+package status
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/andydunstall/piko/server/status/client"
+	yaml "github.com/goccy/go-yaml"
+	"github.com/spf13/cobra"
+)
+
+func newUpstreamCommand(c *client.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upstream",
+		Short: "inspect connected upstreams",
+	}
+
+	cmd.AddCommand(newUpstreamEndpointsCommand(c))
+
+	return cmd
+}
+
+func newUpstreamEndpointsCommand(c *client.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "endpoints",
+		Short: "inspect endpoints",
+		Long: `Inspect endpoints.
+
+Queries the server for the number of upstream connections for each endpoint.
+
+Examples:
+  piko server status upstream endpoints
+`,
+	}
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		showUpstreamEndpoints(c)
+	}
+
+	return cmd
+}
+
+func showUpstreamEndpoints(c *client.Client) {
+	upstream := client.NewUpstream(c)
+
+	endpoints, err := upstream.Endpoints()
+	if err != nil {
+		fmt.Printf("failed to get upstream endpoints: %s\n", err.Error())
+		os.Exit(1)
+	}
+
+	b, _ := yaml.Marshal(endpoints)
+	fmt.Print(string(b))
+}

--- a/server/status/client/upstream.go
+++ b/server/status/client/upstream.go
@@ -1,0 +1,30 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type Upstream struct {
+	client *Client
+}
+
+func NewUpstream(client *Client) *Upstream {
+	return &Upstream{
+		client: client,
+	}
+}
+
+func (c *Upstream) Endpoints() (map[string]int, error) {
+	r, err := c.client.Request("/status/upstream/endpoints")
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	endpoints := make(map[string]int)
+	if err := json.NewDecoder(r).Decode(&endpoints); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	return endpoints, nil
+}

--- a/server/upstream/manager.go
+++ b/server/upstream/manager.go
@@ -145,6 +145,17 @@ func (m *LoadBalancedManager) RemoveConn(u Upstream) {
 	m.metrics.ConnectedUpstreams.Dec()
 }
 
+func (m *LoadBalancedManager) Endpoints() map[string]int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	endpoints := make(map[string]int)
+	for endpointID, lb := range m.localUpstreams {
+		endpoints[endpointID] = len(lb.upstreams)
+	}
+	return endpoints
+}
+
 func (m *LoadBalancedManager) Metrics() *Metrics {
 	return m.metrics
 }

--- a/server/upstream/status.go
+++ b/server/upstream/status.go
@@ -1,0 +1,29 @@
+package upstream
+
+import (
+	"net/http"
+
+	"github.com/andydunstall/piko/server/status"
+	"github.com/gin-gonic/gin"
+)
+
+type Status struct {
+	manager *LoadBalancedManager
+}
+
+func NewStatus(manager *LoadBalancedManager) *Status {
+	return &Status{
+		manager: manager,
+	}
+}
+
+func (s *Status) Register(group *gin.RouterGroup) {
+	group.GET("/endpoints", s.listEndpointsRoute)
+}
+
+func (s *Status) listEndpointsRoute(c *gin.Context) {
+	endpoints := s.manager.Endpoints()
+	c.JSON(http.StatusOK, endpoints)
+}
+
+var _ status.Handler = &Status{}


### PR DESCRIPTION
Adds 'piko server status upstream endpoints' command to list the number of connected upstreams for each endpoint.