### PR TITLE
agent: add tcp listener support

### DIFF
--- a/agent/reverseproxy/server.go
+++ b/agent/reverseproxy/server.go
@@ -30,7 +30,7 @@ func NewServer(
 	registry *prometheus.Registry,
 	logger log.Logger,
 ) *Server {
-	logger = logger.WithSubsystem("reverseproxy")
+	logger = logger.WithSubsystem("proxy.http")
 	logger = logger.With(zap.String("endpoint-id", conf.EndpointID))
 
 	router := gin.New()

--- a/agent/tcpproxy/server.go
+++ b/agent/tcpproxy/server.go
@@ -1,0 +1,147 @@
+package tcpproxy
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/andydunstall/piko/agent/config"
+	"github.com/andydunstall/piko/pkg/log"
+	"go.uber.org/zap"
+)
+
+type Server struct {
+	conf config.ListenerConfig
+
+	ln net.Listener
+
+	dialer *net.Dialer
+
+	conns   map[net.Conn]struct{}
+	connsMu sync.Mutex
+
+	logger       log.Logger
+	accessLogger log.Logger
+}
+
+func NewServer(
+	conf config.ListenerConfig,
+	logger log.Logger,
+) *Server {
+	logger = logger.WithSubsystem("proxy.tcp")
+	logger = logger.With(zap.String("endpoint-id", conf.EndpointID))
+
+	s := &Server{
+		conf: conf,
+		dialer: &net.Dialer{
+			Timeout: conf.Timeout,
+		},
+		conns:        make(map[net.Conn]struct{}),
+		logger:       logger,
+		accessLogger: logger.WithSubsystem("proxy.tcp.access"),
+	}
+
+	return s
+}
+
+func (s *Server) Serve(ln net.Listener) error {
+	s.ln = ln
+
+	s.logger.Info("starting tcp proxy")
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return fmt.Errorf("accept: %w", err)
+		}
+
+		s.addConn(conn)
+		go s.serveConn(conn)
+	}
+}
+
+func (s *Server) Close() error {
+	if s.ln != nil {
+		s.ln.Close()
+	}
+
+	s.connsMu.Lock()
+	defer s.connsMu.Unlock()
+	for conn := range s.conns {
+		conn.Close()
+	}
+
+	return nil
+}
+
+func (s *Server) serveConn(c net.Conn) {
+	defer s.removeConn(c)
+	defer c.Close()
+
+	s.logConnOpened()
+	defer s.logConnClosed()
+
+	host, ok := s.conf.Host()
+	if !ok {
+		// We've already verified the address on boot so don't need to handle
+		// the error.
+		panic("invalid addr: " + s.conf.Addr)
+	}
+	upstream, err := s.dialer.Dial("tcp", host)
+	if err != nil {
+		s.logger.Warn("failed to dial upstream", zap.Error(err))
+		return
+	}
+	defer upstream.Close()
+
+	forward(c, upstream)
+}
+
+func (s *Server) addConn(c net.Conn) {
+	s.connsMu.Lock()
+	defer s.connsMu.Unlock()
+
+	s.conns[c] = struct{}{}
+}
+
+func (s *Server) removeConn(c net.Conn) {
+	s.connsMu.Lock()
+	defer s.connsMu.Unlock()
+
+	delete(s.conns, c)
+}
+
+func (s *Server) logConnOpened() {
+	if s.conf.AccessLog {
+		s.accessLogger.Info("connection opened")
+	} else {
+		s.accessLogger.Debug("connection opened")
+	}
+}
+
+func (s *Server) logConnClosed() {
+	if s.conf.AccessLog {
+		s.accessLogger.Info("connection closed")
+	} else {
+		s.accessLogger.Debug("connection closed")
+	}
+}
+
+func forward(conn1 net.Conn, conn2 net.Conn) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		defer conn1.Close()
+		// nolint
+		io.Copy(conn1, conn2)
+	}()
+	go func() {
+		defer wg.Done()
+		defer conn2.Close()
+		// nolint
+		io.Copy(conn2, conn1)
+	}()
+	wg.Wait()
+}

--- a/cli/agent/tcp.go
+++ b/cli/agent/tcp.go
@@ -11,26 +11,23 @@ import (
 	"go.uber.org/zap"
 )
 
-func newHTTPCommand(conf *config.Config) *cobra.Command {
+func newTCPCommand(conf *config.Config) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "http [endpoint] [addr] [flags]",
+		Use:   "tcp [endpoint] [addr] [flags]",
 		Args:  cobra.ExactArgs(2),
-		Short: "register a http listener",
-		Long: `Listens for HTTP traffic on the given endpoint and forwards
+		Short: "register a tcp listener",
+		Long: `Listens for TCP traffic on the given endpoint and forwards
 incoming connections to your upstream service.
 
-The configured upstream address be a port, host and port or a full URL.
+The configured upstream address be a port or host and port.
 
 Examples:
-  # Listen for connections from endpoint 'my-endpoint' and forward connections
+  # Listen for connections from endpoint 'my-endpoint' and forward
   # to localhost:3000.
-  piko agent http my-endpoint 3000
+  piko agent tcp my-endpoint 3000
 
   # Listen and forward to 10.26.104.56:3000.
-  piko agent http my-endpoint 10.26.104.56:3000
-
-  # Listen and forward to 10.26.104.56:3000 using HTTPS.
-  piko agent http my-endpoint https://10.26.104.56:3000
+  piko agent tcp my-endpoint 10.26.104.56:3000
 `,
 	}
 
@@ -40,7 +37,7 @@ Examples:
 		"access-log",
 		true,
 		`
-Whether to log all incoming HTTP requests and responses as 'info' logs.`,
+Whether to log all incoming connections as 'info' logs.`,
 	)
 
 	var timeout time.Duration
@@ -49,7 +46,7 @@ Whether to log all incoming HTTP requests and responses as 'info' logs.`,
 		"timeout",
 		time.Second*10,
 		`
-Timeout forwarding incoming HTTP requests to the upstream.`,
+Timeout connecting to the upstream.`,
 	)
 
 	var logger log.Logger
@@ -60,7 +57,7 @@ Timeout forwarding incoming HTTP requests to the upstream.`,
 		conf.Listeners = []config.ListenerConfig{{
 			EndpointID: args[0],
 			Addr:       args[1],
-			Protocol:   config.ListenerProtocolHTTP,
+			Protocol:   config.ListenerProtocolTCP,
 			AccessLog:  accessLog,
 			Timeout:    timeout,
 		}}

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/andydunstall/piko/pkg/log"
@@ -27,6 +28,11 @@ func NewLogger(accessLog bool, logger log.Logger) gin.HandlerFunc {
 		s := time.Now()
 
 		c.Next()
+
+		// Ignore internal endpoints.
+		if strings.HasPrefix(c.Request.URL.Path, "/_piko") {
+			return
+		}
 
 		req := &loggedRequest{
 			Proto:           c.Request.Proto,


### PR DESCRIPTION
Adds support for listening for raw TCP traffic on the agent.

Also adds a new 'piko agent tcp' command to create a single TCP listener.