### PR TITLE
server: support clustering with tcp port forwarding

### DIFF
--- a/server/proxy/httpproxy_test.go
+++ b/server/proxy/httpproxy_test.go
@@ -34,7 +34,8 @@ func (m *fakeManager) RemoveConn(_ upstream.Upstream) {
 }
 
 type tcpUpstream struct {
-	addr string
+	addr    string
+	forward bool
 }
 
 func (u *tcpUpstream) Dial() (net.Conn, error) {
@@ -43,6 +44,10 @@ func (u *tcpUpstream) Dial() (net.Conn, error) {
 
 func (u *tcpUpstream) EndpointID() string {
 	return "my-endpoint"
+}
+
+func (u *tcpUpstream) Forward() bool {
+	return u.forward
 }
 
 func TestHTTPProxy_Forward(t *testing.T) {

--- a/server/proxy/server.go
+++ b/server/proxy/server.go
@@ -35,10 +35,12 @@ func NewServer(
 ) *Server {
 	logger = logger.WithSubsystem("proxy")
 
+	httpProxy := NewHTTPProxy(upstreams, proxyConfig.Timeout, logger)
+
 	router := gin.New()
 	s := &Server{
-		httpProxy: NewHTTPProxy(upstreams, proxyConfig.Timeout, logger),
-		tcpProxy:  NewTCPProxy(upstreams, logger),
+		httpProxy: httpProxy,
+		tcpProxy:  NewTCPProxy(upstreams, httpProxy, logger),
 		httpServer: &http.Server{
 			Handler:           router,
 			TLSConfig:         tlsConfig,

--- a/server/proxy/tcpproxy_test.go
+++ b/server/proxy/tcpproxy_test.go
@@ -96,6 +96,7 @@ func TestTCPProxy_Forward(t *testing.T) {
 					}, true
 				},
 			},
+			nil,
 			log.NewNopLogger(),
 		)
 
@@ -119,10 +120,11 @@ func TestTCPProxy_Forward(t *testing.T) {
 			&fakeManager{
 				handler: func(endpointID string, allowForward bool) (upstream.Upstream, bool) {
 					assert.Equal(t, "my-endpoint", endpointID)
-					assert.False(t, allowForward)
+					assert.True(t, allowForward)
 					return nil, false
 				},
 			},
+			nil,
 			log.NewNopLogger(),
 		)
 

--- a/server/upstream/manager_test.go
+++ b/server/upstream/manager_test.go
@@ -19,6 +19,10 @@ func (u *fakeUpstream) Dial() (net.Conn, error) {
 	return nil, nil
 }
 
+func (u *fakeUpstream) Forward() bool {
+	return false
+}
+
 func TestLocalLoadBalancer(t *testing.T) {
 	lb := &loadBalancer{}
 

--- a/server/upstream/upstream.go
+++ b/server/upstream/upstream.go
@@ -14,6 +14,9 @@ import (
 type Upstream interface {
 	EndpointID() string
 	Dial() (net.Conn, error)
+	// Forward indicates whether the upstream is forwarding traffic to a remote
+	// node rather than a client listener.
+	Forward() bool
 }
 
 // ConnUpstream represents a connection to an upstream service thats connected
@@ -38,6 +41,10 @@ func (u *ConnUpstream) Dial() (net.Conn, error) {
 	return u.sess.OpenStream()
 }
 
+func (u *ConnUpstream) Forward() bool {
+	return false
+}
+
 // NodeUpstream represents a remote Piko server node.
 type NodeUpstream struct {
 	endpointID string
@@ -57,4 +64,8 @@ func (u *NodeUpstream) EndpointID() string {
 
 func (u *NodeUpstream) Dial() (net.Conn, error) {
 	return net.Dial("tcp", u.node.ProxyAddr)
+}
+
+func (u *NodeUpstream) Forward() bool {
+	return true
 }


### PR DESCRIPTION
Adds support for forwarding a TCP port forwarding connection to another node in the cluster. This forwards the connection via the HTTP reverse proxy as it uses WebSockets as the underlying connection.