### PR TITLE
forward: add 'piko forward' command

### DIFF
--- a/cli/command.go
+++ b/cli/command.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"github.com/andydunstall/piko/cli/agent"
+	"github.com/andydunstall/piko/cli/forward"
 	"github.com/andydunstall/piko/cli/server"
 	"github.com/andydunstall/piko/cli/workload"
 	"github.com/spf13/cobra"
@@ -37,15 +38,28 @@ proxy that runs alongside your services. It connects to the Piko server,
 registers the configured endpoints, then forwards incoming requests to your
 services.
 
-Such as to register endpoint 'my-endpoint' to forward connections to your
+Such as to register endpoint 'my-endpoint' to forward HTTP requests to your
 service at 'localhost:3000':
 
   $ piko agent http my-endpoint 3000
+
+You can also forward raw TCP using:
+
+  $ piko agent tcp my-endpoint 3000
+
+To forward a local TCP port to an upstream endpoint, use 'piko forward'.
+This listens for TCP connections on the configured local port and forwards them
+to an upstream listener via Piko. Such as to forward port 3000 to endpoint
+'my-endpoint':
+
+  $ piko forward tcp 3000 my-endpoint
+
 `,
 	}
 
 	cmd.AddCommand(server.NewCommand())
 	cmd.AddCommand(agent.NewCommand())
+	cmd.AddCommand(forward.NewCommand())
 	cmd.AddCommand(workload.NewCommand())
 
 	return cmd

--- a/cli/forward/command.go
+++ b/cli/forward/command.go
@@ -1,0 +1,133 @@
+package forward
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/andydunstall/piko/agent/client"
+	"github.com/andydunstall/piko/forward"
+	"github.com/andydunstall/piko/forward/config"
+	"github.com/andydunstall/piko/pkg/build"
+	pikoconfig "github.com/andydunstall/piko/pkg/config"
+	"github.com/andydunstall/piko/pkg/log"
+	rungroup "github.com/oklog/run"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "forward [command] [flags]",
+		Short: "forward local ports to an upstream endpoint",
+		Long: `Piko forward listens on a local port for forwards to the
+configured upstream endpoint.
+
+Such as you may listen on port 3000 and forward connections to endpoint
+'my-endpoint'.
+
+Piko forward supports both YAML configuration and command line flags. Configure
+a YAML file using '--config.path'. When enabling '--config.expand-env', Piko
+will expand environment variables in the loaded YAML configuration.
+
+Examples:
+  # Listen for connections on port 3000 and forward to endpoint "my-endpoint".
+  piko forward tcp 3000 my-endpoint
+
+  # Start all ports configured in forward.yaml
+  piko forward start --config.file ./forward.yaml
+`,
+	}
+
+	var conf config.Config
+	var loadConf pikoconfig.Config
+
+	// Register flags and set default values.
+	conf.RegisterFlags(cmd.PersistentFlags())
+	loadConf.RegisterFlags(cmd.PersistentFlags())
+
+	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if err := loadConf.Load(&conf); err != nil {
+			fmt.Println(err.Error())
+			os.Exit(1)
+		}
+
+		if err := conf.Validate(); err != nil {
+			fmt.Printf("config: %s\n", err.Error())
+			os.Exit(1)
+		}
+	}
+
+	cmd.AddCommand(newStartCommand(&conf))
+	cmd.AddCommand(newTCPCommand(&conf))
+
+	return cmd
+}
+
+func runForward(conf *config.Config, logger log.Logger) error {
+	logger.Info(
+		"starting piko forward",
+		zap.String("version", build.Version),
+	)
+	logger.Debug("piko config", zap.Any("config", conf))
+
+	connectTLSConfig, err := conf.Connect.TLS.Load()
+	if err != nil {
+		return fmt.Errorf("connect tls: %w", err)
+	}
+
+	var group rungroup.Group
+
+	client := client.New(
+		client.WithProxyURL(conf.Connect.URL),
+		client.WithTLSConfig(connectTLSConfig),
+		client.WithLogger(logger.WithSubsystem("client")),
+	)
+
+	for _, portConfig := range conf.Ports {
+		host, _ := portConfig.Host()
+		ln, err := net.Listen("tcp", host)
+		if err != nil {
+			return fmt.Errorf("listen: %s: %w", host, err)
+		}
+
+		forwarder := forward.NewForwarder(
+			portConfig.EndpointID, client, logger.WithSubsystem("forwarder"),
+		)
+
+		group.Add(func() error {
+			if err := forwarder.Forward(ln); err != nil {
+				return fmt.Errorf("serve: %w", err)
+			}
+			return nil
+		}, func(error) {
+			if err := forwarder.Close(); err != nil {
+				logger.Warn("failed to close forwarder", zap.Error(err))
+			}
+		})
+	}
+
+	// Termination handler.
+	signalCtx, signalCancel := context.WithCancel(context.Background())
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)
+	group.Add(func() error {
+		select {
+		case sig := <-signalCh:
+			logger.Info(
+				"received shutdown signal",
+				zap.String("signal", sig.String()),
+			)
+			return nil
+		case <-signalCtx.Done():
+			return nil
+		}
+	}, func(error) {
+		signalCancel()
+	})
+
+	return group.Run()
+}

--- a/cli/forward/start.go
+++ b/cli/forward/start.go
@@ -1,0 +1,50 @@
+package forward
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/andydunstall/piko/forward/config"
+	"github.com/andydunstall/piko/pkg/log"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func newStartCommand(conf *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start [flags]",
+		Short: "open the configured ports",
+		Long: `Opens the configured ports for forwards incoming connections
+to the configured upstream endpoint.
+
+Examples:
+  # Start all ports configured in forward.yaml
+  piko forward start --config.file ./forward.yaml
+`,
+	}
+
+	var logger log.Logger
+
+	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		var err error
+		logger, err = log.NewLogger(conf.Log.Level, conf.Log.Subsystems)
+		if err != nil {
+			fmt.Printf("failed to setup logger: %s\n", err.Error())
+			os.Exit(1)
+		}
+
+		if len(conf.Ports) == 0 {
+			fmt.Printf("no ports configured\n")
+			os.Exit(1)
+		}
+	}
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		if err := runForward(conf, logger); err != nil {
+			logger.Error("failed to run forward", zap.Error(err))
+			os.Exit(1)
+		}
+	}
+
+	return cmd
+}

--- a/cli/forward/tcp.go
+++ b/cli/forward/tcp.go
@@ -1,0 +1,57 @@
+package forward
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/andydunstall/piko/forward/config"
+	"github.com/andydunstall/piko/pkg/log"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+func newTCPCommand(conf *config.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tcp [addr] [endpoint] [flags]",
+		Args:  cobra.ExactArgs(2),
+		Short: "open a tcp port",
+		Long: `Opens a TCP port and forwards to the configured endpoint.
+
+The configured address may be a port or host and port.
+
+Examples:
+  # Listen for connections on port 3000 and forward to endpoint "my-endpoint".
+  piko forward tcp 3000 my-endpoint
+
+  # Listen for connections on 0.0.0.0:3000.
+  piko forward tcp 0.0.0.0:3000 my-endpoint
+`,
+	}
+
+	var logger log.Logger
+
+	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		// Discard any ports in the configuration file and use from command
+		// line.
+		conf.Ports = []config.PortConfig{{
+			Addr:       args[0],
+			EndpointID: args[1],
+		}}
+
+		var err error
+		logger, err = log.NewLogger(conf.Log.Level, conf.Log.Subsystems)
+		if err != nil {
+			fmt.Printf("failed to setup logger: %s\n", err.Error())
+			os.Exit(1)
+		}
+	}
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		if err := runForward(conf, logger); err != nil {
+			logger.Error("failed to run forward", zap.Error(err))
+			os.Exit(1)
+		}
+	}
+
+	return cmd
+}

--- a/forward/config/config.go
+++ b/forward/config/config.go
@@ -1,0 +1,179 @@
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/andydunstall/piko/pkg/log"
+	"github.com/spf13/pflag"
+)
+
+type PortConfig struct {
+	// Addr is the address to listen on.
+	Addr string `json:"addr" yaml:"addr"`
+
+	// EndpointID is the endpoint ID to connect to.
+	EndpointID string `json:"endpoint_id" yaml:"endpoint_id"`
+}
+
+// Host parses the given upstream address into a host and port. Return false if
+// the address is invalid.
+//
+// The addr may be either a a host and port or just a port.
+func (c *PortConfig) Host() (string, bool) {
+	// Port only.
+	port, err := strconv.Atoi(c.Addr)
+	if err == nil && port >= 0 && port < 0xffff {
+		return "localhost:" + c.Addr, true
+	}
+
+	// Host and port.
+	_, _, err = net.SplitHostPort(c.Addr)
+	if err == nil {
+		return c.Addr, true
+	}
+
+	return "", false
+}
+
+func (c *PortConfig) Validate() error {
+	if c.Addr == "" {
+		return fmt.Errorf("missing addr")
+	}
+	if _, ok := c.Host(); !ok {
+		return fmt.Errorf("invalid addr")
+	}
+	if c.EndpointID == "" {
+		return fmt.Errorf("missing endpoint id")
+	}
+	return nil
+}
+
+type TLSConfig struct {
+	// RootCAs contains a path to root certificate authorities to validate
+	// the TLS connection to the Piko server.
+	//
+	// Defaults to using the host root CAs.
+	RootCAs string `json:"root_cas" yaml:"root_cas"`
+}
+
+func (c *TLSConfig) RegisterFlags(fs *pflag.FlagSet, prefix string) {
+	prefix = prefix + ".tls."
+	fs.StringVar(
+		&c.RootCAs,
+		prefix+"root-cas",
+		"",
+		`
+A path to a certificate PEM file containing root certificiate authorities to
+validate the TLS connection to the Piko server.
+
+Defaults to using the host root CAs.`,
+	)
+}
+
+func (c *TLSConfig) Load() (*tls.Config, error) {
+	if c.RootCAs == "" {
+		return nil, nil
+	}
+
+	tlsConfig := &tls.Config{}
+
+	caCert, err := os.ReadFile(c.RootCAs)
+	if err != nil {
+		return nil, fmt.Errorf("open root cas: %s: %w", c.RootCAs, err)
+	}
+	caCertPool := x509.NewCertPool()
+	ok := caCertPool.AppendCertsFromPEM(caCert)
+	if !ok {
+		return nil, fmt.Errorf("parse root cas: %s: %w", c.RootCAs, err)
+	}
+	tlsConfig.RootCAs = caCertPool
+
+	return tlsConfig, nil
+}
+
+type ConnectConfig struct {
+	// URL is the Piko server URL to connect to.
+	URL string
+
+	// Timeout is the timeout attempting to connect to the Piko server.
+	Timeout time.Duration `json:"timeout" yaml:"timeout"`
+
+	TLS TLSConfig `json:"tls" yaml:"tls"`
+}
+
+func (c *ConnectConfig) Validate() error {
+	if c.URL == "" {
+		return fmt.Errorf("missing url")
+	}
+	if _, err := url.Parse(c.URL); err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+	if c.Timeout == 0 {
+		return fmt.Errorf("missing timeout")
+	}
+	return nil
+}
+
+func (c *ConnectConfig) RegisterFlags(fs *pflag.FlagSet) {
+	fs.StringVar(
+		&c.URL,
+		"connect.url",
+		"http://localhost:8000",
+		`
+The Piko server URL to connect to. Note this must be configured to use the
+Piko server 'proxy' port.`,
+	)
+
+	fs.DurationVar(
+		&c.Timeout,
+		"connect.timeout",
+		time.Second*30,
+		`
+Timeout attempting to connect to the Piko server.`,
+	)
+
+	c.TLS.RegisterFlags(fs, "connect")
+}
+
+type Config struct {
+	Ports []PortConfig `json:"ports" yaml:"ports"`
+
+	Connect ConnectConfig `json:"connect" yaml:"connect"`
+
+	Log log.Config `json:"log" yaml:"log"`
+}
+
+func (c *Config) Validate() error {
+	// Note don't validate the number of ports, as some commands don't
+	// require any.
+	for _, e := range c.Ports {
+		if err := e.Validate(); err != nil {
+			if e.EndpointID != "" {
+				return fmt.Errorf("port: %s: %w", e.EndpointID, err)
+			}
+			return fmt.Errorf("port: %w", err)
+		}
+	}
+
+	if err := c.Connect.Validate(); err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+
+	if err := c.Log.Validate(); err != nil {
+		return fmt.Errorf("log: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
+	c.Connect.RegisterFlags(fs)
+	c.Log.RegisterFlags(fs)
+}

--- a/forward/forwarder.go
+++ b/forward/forwarder.go
@@ -1,0 +1,99 @@
+package forward
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+
+	piko "github.com/andydunstall/piko/agent/client"
+	"github.com/andydunstall/piko/pkg/log"
+	"go.uber.org/zap"
+)
+
+type Forwarder struct {
+	client *piko.Client
+
+	endpointID string
+
+	ln net.Listener
+
+	logger log.Logger
+}
+
+func NewForwarder(endpointID string, client *piko.Client, logger log.Logger) *Forwarder {
+	return &Forwarder{
+		client:     client,
+		endpointID: endpointID,
+		logger:     logger,
+	}
+}
+
+func (f *Forwarder) Forward(ln net.Listener) error {
+	f.ln = ln
+	defer ln.Close()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("accept: %w", err)
+		}
+
+		f.logger.Debug(
+			"accepted connection",
+			zap.String("client", conn.RemoteAddr().String()),
+			zap.String("endpoint-id", f.endpointID),
+			zap.Error(err),
+		)
+
+		go f.forwardConn(conn)
+	}
+}
+
+func (f *Forwarder) Close() error {
+	if f.ln != nil {
+		return f.ln.Close()
+	}
+	return nil
+}
+
+func (f *Forwarder) forwardConn(conn net.Conn) {
+	defer conn.Close()
+
+	upstream, err := f.client.Dial(context.Background(), f.endpointID)
+	if err != nil {
+		f.logger.Error(
+			"failed to dial endpoint",
+			zap.String("endpoint-id", f.endpointID),
+			zap.Error(err),
+		)
+		return
+	}
+
+	f.logger.Debug(
+		"dialed endpoint",
+		zap.String("endpoint-id", f.endpointID),
+		zap.Error(err),
+	)
+
+	g := &sync.WaitGroup{}
+	g.Add(2)
+	go func() {
+		defer g.Done()
+		defer conn.Close()
+		// nolint
+		io.Copy(conn, upstream)
+	}()
+	go func() {
+		defer g.Done()
+		defer upstream.Close()
+		// nolint
+		io.Copy(upstream, conn)
+	}()
+	g.Wait()
+}


### PR DESCRIPTION
'piko forward' listens on a local TCP port then forwards incoming traffic to a configured upstream endpoint.