### PR TITLE
workload: add upstream churn

### DIFF
--- a/workload/upstream/upstream.go
+++ b/workload/upstream/upstream.go
@@ -34,11 +34,14 @@ func (u *Upstream) Run(ctx context.Context) error {
 	}))
 	defer server.Close()
 
-	client := client.New(client.WithUpstreamURL(u.serverURL))
+	client := client.New(
+		client.WithUpstreamURL(u.serverURL),
+		client.WithLogger(u.logger),
+	)
 
-	ln, err := client.Listen(context.Background(), u.endpointID)
+	ln, err := client.Listen(ctx, u.endpointID)
 	if err != nil {
-		return fmt.Errorf("listen: %s: %w", ln.EndpointID(), err)
+		return fmt.Errorf("listen: %w", err)
 	}
 	defer ln.Close()
 


### PR DESCRIPTION
Adds --churn.interval and --churn.delay to configure how often each upstream should churn (disconnect and reconnect) and the delay between disconnecting and connecting.