### PR TITLE
server: order server statup and shutdown

### DIFF
--- a/cli/server/command.go
+++ b/cli/server/command.go
@@ -118,11 +118,13 @@ func runServer(conf *config.Config, logger log.Logger) error {
 		return err
 	}
 
-	if err := server.Run(ctx); err != nil {
+	if err := server.Start(); err != nil {
 		return err
 	}
 
-	logger.Info("shutdown complete")
+	if !server.Wait(ctx) {
+		os.Exit(1)
+	}
 
 	return nil
 }

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -58,7 +58,22 @@ func TestServer_AdminRoutes(t *testing.T) {
 
 	t.Run("ready", func(t *testing.T) {
 		url := fmt.Sprintf("http://%s/ready", ln.Addr().String())
+
+		// Not ready.
+
+		s.SetReady(false)
+
 		resp, err := http.Get(url)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+
+		// Ready.
+
+		s.SetReady(true)
+
+		resp, err = http.Get(url)
 		assert.NoError(t, err)
 		defer resp.Body.Close()
 

--- a/server/gossip/gossip.go
+++ b/server/gossip/gossip.go
@@ -72,16 +72,16 @@ func (g *Gossip) JoinOnStartup(ctx context.Context, addrs []string) ([]string, e
 	backoff := backoff.New(5, time.Second, time.Minute)
 	var lastErr error
 	for {
-		if !backoff.Wait(ctx) {
-			return nil, lastErr
-		}
-
 		nodeIDs, err := g.gossiper.Join(addrs)
 		if err == nil {
 			return nodeIDs, nil
 		}
 		g.logger.Warn("failed to join cluster", zap.Error(err))
 		lastErr = err
+
+		if !backoff.Wait(ctx) {
+			return nil, lastErr
+		}
 	}
 }
 

--- a/tests/admin_test.go
+++ b/tests/admin_test.go
@@ -1,0 +1,53 @@
+//go:build system
+
+package tests
+
+import (
+	"net/http"
+	"testing"
+
+	cluster "github.com/andydunstall/piko/workloadv2/cluster"
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests the admin server.
+func TestAdmin(t *testing.T) {
+	// Tests /health returns 200.
+	t.Run("health", func(t *testing.T) {
+		node := cluster.NewNode()
+		node.Start()
+		defer node.Stop()
+
+		resp, err := http.Get("http://" + node.AdminAddr() + "/health")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	// Tests /ready returns 200.
+	t.Run("ready", func(t *testing.T) {
+		node := cluster.NewNode()
+		node.Start()
+		defer node.Stop()
+
+		resp, err := http.Get("http://" + node.AdminAddr() + "/ready")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	// Tests /metrics returns 200.
+	t.Run("metrics", func(t *testing.T) {
+		node := cluster.NewNode()
+		node.Start()
+		defer node.Stop()
+
+		resp, err := http.Get("http://" + node.AdminAddr() + "/metrics")
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}


### PR DESCRIPTION
Rather than start/stop all background goroutines at once, adds an ordering for more graceful startup and shutdown.