### PR TITLE
forward: fix forward configuration

### DIFF
--- a/forward/config/config.go
+++ b/forward/config/config.go
@@ -156,6 +156,9 @@ func Default() *Config {
 			URL:     "http://localhost:8000",
 			Timeout: time.Second * 30,
 		},
+		Log: log.Config{
+			Level: "info",
+		},
 	}
 }
 


### PR DESCRIPTION
Adds missing default value to 'piko forward' CLI.