### PR TITLE
config: test default config is valid

### DIFF
--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Tests the default configuration is valid.
+func TestConfig_Default(t *testing.T) {
+	conf := Default()
+	assert.NoError(t, conf.Validate())
+}
+
 func TestListenerConfig_URL(t *testing.T) {
 	tests := []struct {
 		addr string

--- a/forward/config/config_test.go
+++ b/forward/config/config_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests the default configuration is valid.
+func TestConfig_Default(t *testing.T) {
+	conf := Default()
+	assert.NoError(t, conf.Validate())
+}

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests the default configuration is valid (not including node ID).
+func TestConfig_Default(t *testing.T) {
+	conf := Default()
+	conf.Cluster.NodeID = "my-node"
+	assert.NoError(t, conf.Validate())
+}


### PR DESCRIPTION
Adds unit tests to verify the server, agent for forward default configuration is valid.