### PR TITLE
yamux: updates yamux dependency to github.com/andydunstall/yamux

### DIFF
--- a/client/listener.go
+++ b/client/listener.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"strings"
 
-	"github.com/hashicorp/yamux"
+	"github.com/andydunstall/yamux"
 	"go.uber.org/zap"
 )
 

--- a/client/upstream.go
+++ b/client/upstream.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/hashicorp/yamux"
+	"github.com/andydunstall/yamux"
 	"go.uber.org/zap"
 
 	"github.com/andydunstall/piko/pkg/backoff"

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/andydunstall/piko
 go 1.22
 
 require (
+	github.com/andydunstall/yamux v0.1.3
 	github.com/gin-gonic/gin v1.10.0
 	github.com/goccy/go-yaml v1.11.3
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-sockaddr v1.0.6
-	github.com/hashicorp/yamux v0.1.2-0.20240510232814-6034404dc2ab
 	github.com/oklog/run v1.1.0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/andydunstall/yamux v0.1.3 h1:lTNkGpbbVuAttKhnn5W290a1yMWVav3GnijrcHhjuKU=
+github.com/andydunstall/yamux v0.1.3/go.mod h1:v4C9l2I4bhYdww+IVgjO0o5rVzxXbx2nneuFDHvyM28=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
@@ -45,8 +47,6 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-sockaddr v1.0.6 h1:RSG8rKU28VTUTvEKghe5gIhIQpv8evvNpnDEyqO4u9I=
 github.com/hashicorp/go-sockaddr v1.0.6/go.mod h1:uoUUmtwU7n9Dv3O4SNLeFvg0SxQ3lyjsj6+CCykpaxI=
-github.com/hashicorp/yamux v0.1.2-0.20240510232814-6034404dc2ab h1:PaRHipkPJFApx8wpGeKFoAr4NxXKvXRx0YAVIKot5aI=
-github.com/hashicorp/yamux v0.1.2-0.20240510232814-6034404dc2ab/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/server/upstream/server.go
+++ b/server/upstream/server.go
@@ -8,9 +8,9 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/andydunstall/yamux"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
-	"github.com/hashicorp/yamux"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 

--- a/server/upstream/upstream.go
+++ b/server/upstream/upstream.go
@@ -3,7 +3,7 @@ package upstream
 import (
 	"net"
 
-	"github.com/hashicorp/yamux"
+	"github.com/andydunstall/yamux"
 
 	"github.com/andydunstall/piko/server/cluster"
 )


### PR DESCRIPTION
This is a temporary fork to tag the latest version, rather than depend on an arbitrary commit.