### PR TITLE
server: add support for admin authentication

### DIFF
--- a/docs/server/server.md
+++ b/docs/server/server.md
@@ -230,6 +230,28 @@ admin:
   # advertise address of '10.26.104.14:8002'.
   advertise_addr: ""
 
+  auth:
+    # Secret key to authenticate HMAC endpoint connection JWTs.
+    hmac_secret_key: ""
+
+    # Public key to authenticate RSA endpoint connection JWTs.
+    rsa_public_key: ""
+
+    # Public key to authenticate ECDSA endpoint connection JWTs.
+    ecdsa_public_key: ""
+
+    # Audience of endpoint connection JWT token to verify.
+    #
+    # If given the JWT 'aud' claim must match the given audience. Otherwise it
+    # is ignored.
+    audience: ""
+
+    # Issuer of endpoint connection JWT token to verify.
+    #
+    # If given the JWT 'iss' claim must match the given issuer. Otherwise it
+    # is ignored.
+    issuer: ""
+
   tls:
     # Whether to enable TLS on the listener.
     #

--- a/pikotest/cluster/node.go
+++ b/pikotest/cluster/node.go
@@ -38,6 +38,7 @@ func NewNode(opts ...Option) *Node {
 	conf.Admin.BindAddr = "127.0.0.1:0"
 	conf.Gossip.BindAddr = "127.0.0.1:0"
 	conf.Gossip.Interval = time.Millisecond * 10
+	conf.Admin.Auth = options.authConfig
 	conf.Upstream.Auth = options.authConfig
 
 	// If TLS is enabled, generate a certificate and root CA then write to a

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -320,6 +320,8 @@ type AdminConfig struct {
 	// AdvertiseAddr is the address to advertise to other nodes.
 	AdvertiseAddr string `json:"advertise_addr" yaml:"advertise_addr"`
 
+	Auth auth.Config `json:"auth" yaml:"auth"`
+
 	TLS TLSConfig `json:"tls" yaml:"tls"`
 }
 
@@ -361,6 +363,8 @@ If the bind address does not include an IP (such as ':8002') the nodes
 private IP will be used, such as a bind address of ':8002' may have an
 advertise address of '10.26.104.14:8002'.`,
 	)
+
+	c.Auth.RegisterFlags(fs, "admin")
 
 	c.TLS.RegisterFlags(fs, "admin")
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -71,6 +71,13 @@ admin:
   bind_addr: 10.15.104.25:8002
   advertise_addr: 1.2.3.4:8002
 
+  auth:
+    hmac_secret_key: hmac-secret-key
+    rsa_public_key: rsa-public-key
+    ecdsa_public_key: ecdsa-public-key
+    audience: my-audience
+    issuer: my-issuer
+
   tls:
     enabled: true
     cert: /piko/cert.pem
@@ -152,6 +159,13 @@ grace_period: 2m
 		Admin: AdminConfig{
 			BindAddr:      "10.15.104.25:8002",
 			AdvertiseAddr: "1.2.3.4:8002",
+			Auth: auth.Config{
+				HMACSecretKey:  "hmac-secret-key",
+				RSAPublicKey:   "rsa-public-key",
+				ECDSAPublicKey: "ecdsa-public-key",
+				Audience:       "my-audience",
+				Issuer:         "my-issuer",
+			},
 			TLS: TLSConfig{
 				Enabled: true,
 				Cert:    "/piko/cert.pem",
@@ -210,6 +224,11 @@ func TestConfig_LoadFlags(t *testing.T) {
 		"--upstream.tls.key", "/piko/key.pem",
 		"--admin.bind-addr", "10.15.104.25:8002",
 		"--admin.advertise-addr", "1.2.3.4:8002",
+		"--admin.auth.hmac-secret-key", "hmac-secret-key",
+		"--admin.auth.rsa-public-key", "rsa-public-key",
+		"--admin.auth.ecdsa-public-key", "ecdsa-public-key",
+		"--admin.auth.audience", "my-audience",
+		"--admin.auth.issuer", "my-issuer",
 		"--admin.tls.enabled",
 		"--admin.tls.cert", "/piko/cert.pem",
 		"--admin.tls.key", "/piko/key.pem",
@@ -278,6 +297,13 @@ func TestConfig_LoadFlags(t *testing.T) {
 		Admin: AdminConfig{
 			BindAddr:      "10.15.104.25:8002",
 			AdvertiseAddr: "1.2.3.4:8002",
+			Auth: auth.Config{
+				HMACSecretKey:  "hmac-secret-key",
+				RSAPublicKey:   "rsa-public-key",
+				ECDSAPublicKey: "ecdsa-public-key",
+				Audience:       "my-audience",
+				Issuer:         "my-issuer",
+			},
 			TLS: TLSConfig{
 				Enabled: true,
 				Cert:    "/piko/cert.pem",

--- a/server/server.go
+++ b/server/server.go
@@ -149,6 +149,14 @@ func NewServer(conf *config.Config, logger log.Logger) (*Server, error) {
 
 	// Admin server.
 
+	var adminVerifier auth.Verifier
+	if conf.Admin.Auth.Enabled() {
+		verifierConf, err := conf.Admin.Auth.Load()
+		if err != nil {
+			return nil, fmt.Errorf("admin: load auth: %w", err)
+		}
+		adminVerifier = auth.NewJWTVerifier(verifierConf)
+	}
 	adminTLSConfig, err := conf.Admin.TLS.Load()
 	if err != nil {
 		return nil, fmt.Errorf("admin tls: %w", err)
@@ -156,6 +164,7 @@ func NewServer(conf *config.Config, logger log.Logger) (*Server, error) {
 	s.adminServer = admin.NewServer(
 		s.clusterState,
 		registry,
+		adminVerifier,
 		adminTLSConfig,
 		logger,
 	)

--- a/server/upstream/server_test.go
+++ b/server/upstream/server_test.go
@@ -229,7 +229,7 @@ func TestServer_Authentication(t *testing.T) {
 		verifier := &fakeVerifier{
 			handler: func(token string) (*auth.Token, error) {
 				assert.Equal(t, "123", token)
-				return &auth.Token{}, auth.ErrInvalidToken
+				return nil, auth.ErrInvalidToken
 			},
 		}
 

--- a/tests/server/admin_test.go
+++ b/tests/server/admin_test.go
@@ -3,12 +3,16 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 
 	cluster "github.com/andydunstall/piko/pikotest/cluster"
+	"github.com/andydunstall/piko/pkg/auth"
 )
 
 // Tests the admin server.
@@ -50,5 +54,88 @@ func TestAdmin(t *testing.T) {
 		defer resp.Body.Close()
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+// Tests admin server authentication.
+func TestAdmin_Auth(t *testing.T) {
+	endpointClaims := auth.JWTClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+		Piko: auth.PikoClaims{
+			Endpoints: []string{"my-endpoint"},
+		},
+	}
+
+	// Tests a client authenticating with a valid token.
+	t.Run("valid", func(t *testing.T) {
+		secretKey := generateTestHSKey()
+		node := cluster.NewNode(cluster.WithAuthConfig(auth.Config{
+			HMACSecretKey: string(secretKey),
+		}))
+		node.Start()
+		defer node.Stop()
+
+		token := jwt.NewWithClaims(jwt.SigningMethodHS512, endpointClaims)
+		tokenString, err := token.SignedString([]byte(secretKey))
+		assert.NoError(t, err)
+
+		url := fmt.Sprintf("http://%s/health", node.AdminAddr())
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.Header.Add("Authorization", "Bearer "+tokenString)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	// Tests an upstream authenticating with an invalid token (signed by
+	// the wrong key).
+	t.Run("valid", func(t *testing.T) {
+		secretKey := generateTestHSKey()
+		node := cluster.NewNode(cluster.WithAuthConfig(auth.Config{
+			HMACSecretKey: string(secretKey),
+		}))
+		node.Start()
+		defer node.Stop()
+
+		token := jwt.NewWithClaims(jwt.SigningMethodHS512, endpointClaims)
+		tokenString, err := token.SignedString([]byte("invalid-key"))
+		assert.NoError(t, err)
+
+		url := fmt.Sprintf("http://%s/health", node.AdminAddr())
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+		req.Header.Add("Authorization", "Bearer "+tokenString)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	// Tests an unauthenticated client attempting to connect.
+	t.Run("unauthenticated", func(t *testing.T) {
+		secretKey := generateTestHSKey()
+		node := cluster.NewNode(cluster.WithAuthConfig(auth.Config{
+			HMACSecretKey: string(secretKey),
+		}))
+		node.Start()
+		defer node.Stop()
+
+		url := fmt.Sprintf("http://%s/health", node.AdminAddr())
+		req, _ := http.NewRequest(http.MethodGet, url, nil)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		assert.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	})
 }


### PR DESCRIPTION
Adds 'config.admin.auth' to configure JWT configuration for admin endpoints.