### PR TITLE
gossip: move gossip config under cluster

### DIFF
--- a/docs/server/server.md
+++ b/docs/server/server.md
@@ -50,39 +50,6 @@ The server supports the following YAML configuration (where most parameters
 have corresponding command line flags):
 
 ```
-cluster:
-  # A unique identifier for the node in the cluster.
-  #
-  # By default a random ID will be generated for the node.
-  node_id: ""
-
-  # A prefix for the node ID.
-  #
-  # Piko will generate a unique random identifier for the node and append it to
-  # the given prefix.
-  #
-  # Such as you could use the node or pod  name as a prefix, then add a unique
-  # identifier to ensure the node ID is unique across restarts.
-  node_id_prefix: ""
-
-  # A list of addresses of members in the cluster to join.
-  #
-  # This may be either addresses of specific nodes, such as
-  # '--cluster.join 10.26.104.14,10.26.104.75', or a domain that resolves to
-  # the addresses of the nodes in the cluster (e.g. a Kubernetes headless
-  # service), such as '--cluster.join piko.prod-piko-ns'.
-  #
-  # Each address must include the host, and may optionally include a port. If no
-  # port is given, the gossip port of this node is used.
-  #
-  # Note each node propagates membership information to the other known nodes,
-  # so the initial set of configured members only needs to be a subset of nodes.
-  join: []
-
-  # Whether the server node should abort if it is configured with more than one
-  # node to join (excluding itself) but fails to join any members.
-  abort_if_join_fails: true
-
 proxy:
   # The host/port to listen for incoming proxy connections.
   #
@@ -203,35 +170,68 @@ upstream:
     # Path to the PEM encoded key file.
     key: ""
 
-gossip:
-  # The host/port to listen for inter-node gossip traffic.
+cluster:
+  # A unique identifier for the node in the cluster.
   #
-  # If the host is unspecified it defaults to all listeners, such as
-  # '--gossip.bind-addr :8003' will listen on '0.0.0.0:8003'.
-  bind_addr: ":8003"
+  # By default a random ID will be generated for the node.
+  node_id: ""
 
-  # Gossip listen address to advertise to other nodes in the cluster. This is the
-  # address other nodes will used to gossip with the node.
+  # A prefix for the node ID.
   #
-  # Such as if the listen address is ':8003', the advertised address may be
-  # '10.26.104.45:8003' or 'node1.cluster:8003'.
+  # Piko will generate a unique random identifier for the node and append it to
+  # the given prefix.
   #
-  # By default, if the bind address includes an IP to bind to that will be used.
-  # If the bind address does not include an IP (such as ':8003') the nodes
-  # private IP will be used, such as a bind address of ':8003' may have an
-  # advertise address of '10.26.104.14:8003'.
-  advertise_addr: ""
+  # Such as you could use the node or pod  name as a prefix, then add a unique
+  # identifier to ensure the node ID is unique across restarts.
+  node_id_prefix: ""
 
-  # The interval to initiate rounds of gossip.
+  # A list of addresses of members in the cluster to join.
   #
-  # Each gossip round selects another known node to synchronize with.`,
-  interval: 500ms
+  # This may be either addresses of specific nodes, such as
+  # '--cluster.join 10.26.104.14,10.26.104.75', or a domain that resolves to
+  # the addresses of the nodes in the cluster (e.g. a Kubernetes headless
+  # service), such as '--cluster.join piko.prod-piko-ns'.
+  #
+  # Each address must include the host, and may optionally include a port. If no
+  # port is given, the gossip port of this node is used.
+  #
+  # Note each node propagates membership information to the other known nodes,
+  # so the initial set of configured members only needs to be a subset of nodes.
+  join: []
 
-  # The maximum size of any packet sent.
-  #
-  # Depending on your networks MTU you may be able to increase to include more data
-  # in each packet.
-  max_packet_size: 1400
+  # Whether the server node should abort if it is configured with more than one
+  # node to join (excluding itself) but fails to join any members.
+  abort_if_join_fails: true
+
+  gossip:
+    # The host/port to listen for inter-node gossip traffic.
+    #
+    # If the host is unspecified it defaults to all listeners, such as
+    # a bind address of ':8003' will listen on '0.0.0.0:8003'.
+    bind_addr: ":8003"
+
+    # Gossip listen address to advertise to other nodes in the cluster. This is the
+    # address other nodes will used to gossip with the node.
+    #
+    # Such as if the listen address is ':8003', the advertised address may be
+    # '10.26.104.45:8003' or 'node1.cluster:8003'.
+    #
+    # By default, if the bind address includes an IP to bind to that will be used.
+    # If the bind address does not include an IP (such as ':8003') the nodes
+    # private IP will be used, such as a bind address of ':8003' may have an
+    # advertise address of '10.26.104.14:8003'.
+    advertise_addr: ""
+
+    # The interval to initiate rounds of gossip.
+    #
+    # Each gossip round selects another known node to synchronize with.`,
+    interval: 100ms
+
+    # The maximum size of any packet sent.
+    #
+    # Depending on your networks MTU you may be able to increase to include more data
+    # in each packet.
+    max_packet_size: 1400
 
 admin:
   # The host/port to listen for incoming admin connections.

--- a/pikotest/cluster/node.go
+++ b/pikotest/cluster/node.go
@@ -31,13 +31,13 @@ func NewNode(opts ...Option) *Node {
 	}
 
 	conf := config.Default()
-	conf.Cluster.NodeID = cluster.GenerateNodeID()
-	conf.Cluster.Join = options.join
 	conf.Proxy.BindAddr = "127.0.0.1:0"
 	conf.Upstream.BindAddr = "127.0.0.1:0"
 	conf.Admin.BindAddr = "127.0.0.1:0"
-	conf.Gossip.BindAddr = "127.0.0.1:0"
-	conf.Gossip.Interval = time.Millisecond * 10
+	conf.Cluster.NodeID = cluster.GenerateNodeID()
+	conf.Cluster.Join = options.join
+	conf.Cluster.Gossip.BindAddr = "127.0.0.1:0"
+	conf.Cluster.Gossip.Interval = time.Millisecond * 10
 	conf.Proxy.Auth = options.authConfig
 	conf.Upstream.Auth = options.authConfig
 	conf.Admin.Auth = options.authConfig
@@ -123,7 +123,7 @@ func (n *Node) AdminAddr() string {
 }
 
 func (n *Node) GossipAddr() string {
-	return n.server.Config().Gossip.AdvertiseAddr
+	return n.server.Config().Cluster.Gossip.AdvertiseAddr
 }
 
 func (n *Node) ClusterState() *cluster.State {

--- a/pkg/gossip/config.go
+++ b/pkg/gossip/config.go
@@ -34,21 +34,23 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
+func (c *Config) RegisterFlags(fs *pflag.FlagSet, prefix string) {
+	prefix = prefix + ".gossip."
+
 	fs.StringVar(
 		&c.BindAddr,
-		"gossip.bind-addr",
+		prefix+"bind-addr",
 		c.BindAddr,
 		`
 The host/port to listen for inter-node gossip traffic.
 
 If the host is unspecified it defaults to all listeners, such as
-'--gossip.bind-addr :8003' will listen on '0.0.0.0:8003'`,
+a bind address ':8003' will listen on '0.0.0.0:8003'`,
 	)
 
 	fs.StringVar(
 		&c.AdvertiseAddr,
-		"gossip.advertise-addr",
+		prefix+"advertise-addr",
 		c.AdvertiseAddr,
 		`
 Gossip listen address to advertise to other nodes in the cluster. This is the
@@ -65,7 +67,7 @@ advertise address of '10.26.104.14:8003'.`,
 
 	fs.DurationVar(
 		&c.Interval,
-		"gossip.interval",
+		prefix+"interval",
 		c.Interval,
 		`
 The interval to initiate rounds of gossip.
@@ -75,7 +77,7 @@ Each gossip round selects another known node to synchronize with.`,
 
 	fs.IntVar(
 		&c.MaxPacketSize,
-		"gossip.max-packet-size",
+		prefix+"max-packet-size",
 		c.MaxPacketSize,
 		`
 The maximum size of any packet sent.

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -24,15 +24,6 @@ func TestConfig_Default(t *testing.T) {
 // Tests loading the server configuration from YAML.
 func TestConfig_LoadYAML(t *testing.T) {
 	yaml := `
-cluster:
-  node_id: "my-node"
-  join:
-    - 10.26.104.12:8003
-    - 10.26.104.73:8003
-    - 10.26.104.28:8003
-  join_timeout: 2m
-  abort_if_join_fails: true
-
 proxy:
   bind_addr: 10.15.104.25:8000
   advertise_addr: 1.2.3.4:8000
@@ -90,11 +81,20 @@ admin:
     cert: /piko/cert.pem
     key: /piko/key.pem
 
-gossip:
-  bind_addr: 10.15.104.25:8003
-  advertise_addr: 1.2.3.4:8003
-  interval: 100ms
-  max_packet_size: 1400
+cluster:
+  node_id: "my-node"
+  join:
+    - 10.26.104.12:8003
+    - 10.26.104.73:8003
+    - 10.26.104.28:8003
+  join_timeout: 2m
+  abort_if_join_fails: true
+
+  gossip:
+    bind_addr: 10.15.104.25:8003
+    advertise_addr: 1.2.3.4:8003
+    interval: 100ms
+    max_packet_size: 1400
 
 usage:
   disable: true
@@ -119,16 +119,6 @@ grace_period: 2m
 	assert.NoError(t, config.Load(&loadedConf, f.Name(), false))
 
 	expectedConf := Config{
-		Cluster: ClusterConfig{
-			NodeID: "my-node",
-			Join: []string{
-				"10.26.104.12:8003",
-				"10.26.104.73:8003",
-				"10.26.104.28:8003",
-			},
-			JoinTimeout:      2 * time.Minute,
-			AbortIfJoinFails: true,
-		},
 		Proxy: ProxyConfig{
 			BindAddr:      "10.15.104.25:8000",
 			AdvertiseAddr: "1.2.3.4:8000",
@@ -186,11 +176,21 @@ grace_period: 2m
 				Key:     "/piko/key.pem",
 			},
 		},
-		Gossip: gossip.Config{
-			BindAddr:      "10.15.104.25:8003",
-			AdvertiseAddr: "1.2.3.4:8003",
-			Interval:      time.Millisecond * 100,
-			MaxPacketSize: 1400,
+		Cluster: ClusterConfig{
+			NodeID: "my-node",
+			Join: []string{
+				"10.26.104.12:8003",
+				"10.26.104.73:8003",
+				"10.26.104.28:8003",
+			},
+			JoinTimeout:      2 * time.Minute,
+			AbortIfJoinFails: true,
+			Gossip: gossip.Config{
+				BindAddr:      "10.15.104.25:8003",
+				AdvertiseAddr: "1.2.3.4:8003",
+				Interval:      time.Millisecond * 100,
+				MaxPacketSize: 1400,
+			},
 		},
 		Usage: UsageConfig{
 			Disable: true,
@@ -210,10 +210,6 @@ grace_period: 2m
 // Tests loading the server configuration from flags.
 func TestConfig_LoadFlags(t *testing.T) {
 	args := []string{
-		"--cluster.node-id", "my-node",
-		"--cluster.join", "10.26.104.12:8003,10.26.104.73:8003,10.26.104.28:8003",
-		"--cluster.join-timeout", "2m",
-		"--cluster.abort-if-join-fails",
 		"--proxy.bind-addr", "10.15.104.25:8000",
 		"--proxy.advertise-addr", "1.2.3.4:8000",
 		"--proxy.timeout", "20s",
@@ -251,10 +247,14 @@ func TestConfig_LoadFlags(t *testing.T) {
 		"--admin.tls.enabled",
 		"--admin.tls.cert", "/piko/cert.pem",
 		"--admin.tls.key", "/piko/key.pem",
-		"--gossip.bind-addr", "10.15.104.25:8003",
-		"--gossip.advertise-addr", "1.2.3.4:8003",
-		"--gossip.interval", "100ms",
-		"--gossip.max-packet-size", "1400",
+		"--cluster.node-id", "my-node",
+		"--cluster.join", "10.26.104.12:8003,10.26.104.73:8003,10.26.104.28:8003",
+		"--cluster.join-timeout", "2m",
+		"--cluster.abort-if-join-fails",
+		"--cluster.gossip.bind-addr", "10.15.104.25:8003",
+		"--cluster.gossip.advertise-addr", "1.2.3.4:8003",
+		"--cluster.gossip.interval", "100ms",
+		"--cluster.gossip.max-packet-size", "1400",
 		"--usage.disable",
 		"--log.level", "info",
 		"--log.subsystems", "foo,bar",
@@ -269,16 +269,6 @@ func TestConfig_LoadFlags(t *testing.T) {
 	assert.NoError(t, fs.Parse(args))
 
 	expectedConf := Config{
-		Cluster: ClusterConfig{
-			NodeID: "my-node",
-			Join: []string{
-				"10.26.104.12:8003",
-				"10.26.104.73:8003",
-				"10.26.104.28:8003",
-			},
-			JoinTimeout:      2 * time.Minute,
-			AbortIfJoinFails: true,
-		},
 		Proxy: ProxyConfig{
 			BindAddr:      "10.15.104.25:8000",
 			AdvertiseAddr: "1.2.3.4:8000",
@@ -336,11 +326,21 @@ func TestConfig_LoadFlags(t *testing.T) {
 				Key:     "/piko/key.pem",
 			},
 		},
-		Gossip: gossip.Config{
-			BindAddr:      "10.15.104.25:8003",
-			AdvertiseAddr: "1.2.3.4:8003",
-			Interval:      time.Millisecond * 100,
-			MaxPacketSize: 1400,
+		Cluster: ClusterConfig{
+			NodeID: "my-node",
+			Join: []string{
+				"10.26.104.12:8003",
+				"10.26.104.73:8003",
+				"10.26.104.28:8003",
+			},
+			JoinTimeout:      2 * time.Minute,
+			AbortIfJoinFails: true,
+			Gossip: gossip.Config{
+				BindAddr:      "10.15.104.25:8003",
+				AdvertiseAddr: "1.2.3.4:8003",
+				Interval:      time.Millisecond * 100,
+				MaxPacketSize: 1400,
+			},
 		},
 		Usage: UsageConfig{
 			Disable: true,

--- a/server/server.go
+++ b/server/server.go
@@ -338,9 +338,9 @@ func (s *Server) Wait(ctx context.Context) bool {
 }
 
 func (s *Server) startGossip() error {
-	gossipStreamLn, err := net.Listen("tcp", s.conf.Gossip.BindAddr)
+	gossipStreamLn, err := net.Listen("tcp", s.conf.Cluster.Gossip.BindAddr)
 	if err != nil {
-		return fmt.Errorf("listen: %s: %w", s.conf.Gossip.BindAddr, err)
+		return fmt.Errorf("listen: %s: %w", s.conf.Cluster.Gossip.BindAddr, err)
 	}
 
 	gossipPacketLn, err := net.ListenUDP("udp", &net.UDPAddr{
@@ -348,10 +348,10 @@ func (s *Server) startGossip() error {
 		Port: gossipStreamLn.Addr().(*net.TCPAddr).Port,
 	})
 	if err != nil {
-		return fmt.Errorf("listen: %s: %w", s.conf.Gossip.BindAddr, err)
+		return fmt.Errorf("listen: %s: %w", s.conf.Cluster.Gossip.BindAddr, err)
 	}
 
-	if s.conf.Gossip.AdvertiseAddr == "" {
+	if s.conf.Cluster.Gossip.AdvertiseAddr == "" {
 		advertiseAddr, err := advertiseAddrFromListenAddr(
 			gossipStreamLn.Addr().String(),
 		)
@@ -359,14 +359,14 @@ func (s *Server) startGossip() error {
 			// Should never happen.
 			panic("invalid listen address: " + err.Error())
 		}
-		s.conf.Gossip.AdvertiseAddr = advertiseAddr
+		s.conf.Cluster.Gossip.AdvertiseAddr = advertiseAddr
 	}
 
 	s.gossiper = gossip.NewGossip(
 		s.clusterState,
 		gossipStreamLn,
 		gossipPacketLn,
-		&s.conf.Gossip,
+		&s.conf.Cluster.Gossip,
 		s.logger,
 	)
 	s.gossiper.Metrics().Register(s.registry)


### PR DESCRIPTION
Moves 'gossip' config to 'cluster.gossip', since gossip is part of the cluster configuration.