### PR TITLE
feat(logs): Add error logs for io.Copy if error isn't EOF

### DIFF
--- a/agent/tcpproxy/server.go
+++ b/agent/tcpproxy/server.go
@@ -138,7 +138,7 @@ func (s *Server) forward(conn net.Conn, upstream net.Conn) {
 		defer conn.Close()
 		_, err := io.Copy(conn, upstream)
 		if err != nil && !errors.Is(err, io.EOF) {
-			s.logger.Error("failure to copy from upstream to connection", zap.Error(err))
+			s.logger.Debug("failure to copy from upstream to connection", zap.Error(err))
 		}
 	}()
 	go func() {
@@ -146,7 +146,7 @@ func (s *Server) forward(conn net.Conn, upstream net.Conn) {
 		defer upstream.Close()
 		_, err := io.Copy(upstream, conn)
 		if err != nil && !errors.Is(err, io.EOF) {
-			s.logger.Error("failure to copy from connection to upstream", zap.Error(err))
+			s.logger.Debug("failure to copy from connection to upstream", zap.Error(err))
 		}
 	}()
 	wg.Wait()

--- a/client/forwarder.go
+++ b/client/forwarder.go
@@ -105,7 +105,7 @@ func (f *Forwarder) forward(downstream net.Conn) {
 		defer downstream.Close()
 		_, err := io.Copy(downstream, upstream)
 		if err != nil && !errors.Is(err, io.EOF) {
-			f.logger.Error("failure to copy from upstream to downstream", zap.String("addr", f.addr), zap.Error(err))
+			f.logger.Debug("failure to copy from upstream to downstream", zap.String("addr", f.addr), zap.Error(err))
 		}
 	}()
 
@@ -114,7 +114,7 @@ func (f *Forwarder) forward(downstream net.Conn) {
 		defer upstream.Close()
 		_, err := io.Copy(upstream, downstream)
 		if err != nil && !errors.Is(err, io.EOF) {
-			f.logger.Error("failure to copy from downstream to upstream", zap.String("addr", f.addr), zap.Error(err))
+			f.logger.Debug("failure to copy from downstream to upstream", zap.String("addr", f.addr), zap.Error(err))
 		}
 	}()
 

--- a/forward/forwarder.go
+++ b/forward/forwarder.go
@@ -89,7 +89,7 @@ func (f *Forwarder) forwardConn(conn net.Conn) {
 		defer conn.Close()
 		_, err := io.Copy(conn, upstream)
 		if err != nil && !errors.Is(err, io.EOF) {
-			f.logger.Error("failure to copy from upstream to connection", zap.String("endpoint-id", f.endpointID), zap.Error(err))
+			f.logger.Debug("failure to copy from upstream to connection", zap.String("endpoint-id", f.endpointID), zap.Error(err))
 		}
 	}()
 	go func() {
@@ -97,7 +97,7 @@ func (f *Forwarder) forwardConn(conn net.Conn) {
 		defer upstream.Close()
 		_, err := io.Copy(upstream, conn)
 		if err != nil && !errors.Is(err, io.EOF) {
-			f.logger.Error("failure to copy from connection to upstream", zap.String("endpoint-id", f.endpointID), zap.Error(err))
+			f.logger.Debug("failure to copy from connection to upstream", zap.String("endpoint-id", f.endpointID), zap.Error(err))
 		}
 	}()
 	g.Wait()

--- a/server/proxy/tcpproxy.go
+++ b/server/proxy/tcpproxy.go
@@ -96,7 +96,7 @@ func (p *TCPProxy) forward(upstream net.Conn, downstream net.Conn) {
 		defer upstream.Close()
 		_, err := io.Copy(upstream, downstream)
 		if err != nil && !errors.Is(err, io.EOF) {
-			p.logger.Error("failure to copy from downstream to upstream", zap.Error(err))
+			p.logger.Debug("failure to copy from downstream to upstream", zap.Error(err))
 		}
 	}()
 	go func() {
@@ -104,7 +104,7 @@ func (p *TCPProxy) forward(upstream net.Conn, downstream net.Conn) {
 		defer downstream.Close()
 		_, err := io.Copy(downstream, upstream)
 		if err != nil && !errors.Is(err, io.EOF) {
-			p.logger.Error("failure to copy from upstream to downstream", zap.Error(err))
+			p.logger.Debug("failure to copy from upstream to downstream", zap.Error(err))
 		}
 	}()
 	wg.Wait()


### PR DESCRIPTION
It seems as though on `io.Copy`, an `EOF` constitutes the normal pattern of a successful copy, but I am checking for `io.EOF` anyway just to be safe.

If the error isn't an `io.EOF`, I think having a log message indicating what went wrong might be good for the user experience.

Let me know your thoughts, what do you think? @andydunstall

Right now in `k8s` as we are using `piko` in TCP mode, we are seeing the connection close on the `agent` side for some peculiar reason (not sure what it is yet), but the error log would be good to have as general diagnostics.


Also if the log messages can be better, let me know. I just went with something pretty general:

```
failure to copy...
```