### PR TITLE
tcp: add copy closed logs

### DIFF
--- a/agent/tcpproxy/server.go
+++ b/agent/tcpproxy/server.go
@@ -1,7 +1,6 @@
 package tcpproxy
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -137,16 +136,16 @@ func (s *Server) forward(conn net.Conn, upstream net.Conn) {
 		defer wg.Done()
 		defer conn.Close()
 		_, err := io.Copy(conn, upstream)
-		if err != nil && !errors.Is(err, io.EOF) {
-			s.logger.Debug("failure to copy from upstream to connection", zap.Error(err))
+		if err != nil {
+			s.logger.Debug("copy to conn closed", zap.Error(err))
 		}
 	}()
 	go func() {
 		defer wg.Done()
 		defer upstream.Close()
 		_, err := io.Copy(upstream, conn)
-		if err != nil && !errors.Is(err, io.EOF) {
-			s.logger.Debug("failure to copy from connection to upstream", zap.Error(err))
+		if err != nil {
+			s.logger.Debug("copy to upstream closed", zap.Error(err))
 		}
 	}()
 	wg.Wait()

--- a/agent/tcpproxy/server.go
+++ b/agent/tcpproxy/server.go
@@ -138,7 +138,7 @@ func (s *Server) forward(conn net.Conn, upstream net.Conn) {
 		defer conn.Close()
 		_, err := io.Copy(conn, upstream)
 		if err != nil && !errors.Is(err, io.EOF) {
-			s.logger.Error("failure to copy from upstream to connection", zap.Error(err))
+			s.logger.Debug("failure to copy from upstream to connection", zap.Error(err))
 		}
 	}()
 	go func() {
@@ -146,7 +146,7 @@ func (s *Server) forward(conn net.Conn, upstream net.Conn) {
 		defer upstream.Close()
 		_, err := io.Copy(upstream, conn)
 		if err != nil && !errors.Is(err, io.EOF) {
-			s.logger.Error("failure to copy from connection to upstream", zap.Error(err))
+			s.logger.Debug("failure to copy from connection to upstream", zap.Error(err))
 		}
 	}()
 	wg.Wait()

--- a/client/forwarder.go
+++ b/client/forwarder.go
@@ -105,7 +105,7 @@ func (f *Forwarder) forward(downstream net.Conn) {
 		defer downstream.Close()
 		_, err := io.Copy(downstream, upstream)
 		if err != nil && !errors.Is(err, io.EOF) {
-			f.logger.Error("failure to copy from upstream to downstream", zap.String("addr", f.addr), zap.Error(err))
+			f.logger.Debug("failure to copy from upstream to downstream", zap.String("addr", f.addr), zap.Error(err))
 		}
 	}()
 
@@ -114,7 +114,7 @@ func (f *Forwarder) forward(downstream net.Conn) {
 		defer upstream.Close()
 		_, err := io.Copy(upstream, downstream)
 		if err != nil && !errors.Is(err, io.EOF) {
-			f.logger.Error("failure to copy from downstream to upstream", zap.String("addr", f.addr), zap.Error(err))
+			f.logger.Debug("failure to copy from downstream to upstream", zap.String("addr", f.addr), zap.Error(err))
 		}
 	}()
 

--- a/client/forwarder.go
+++ b/client/forwarder.go
@@ -104,8 +104,12 @@ func (f *Forwarder) forward(downstream net.Conn) {
 		defer g.Done()
 		defer downstream.Close()
 		_, err := io.Copy(downstream, upstream)
-		if err != nil && !errors.Is(err, io.EOF) {
-			f.logger.Debug("failure to copy from upstream to downstream", zap.String("addr", f.addr), zap.Error(err))
+		if err != nil {
+			f.logger.Debug(
+				"copy to downstream closed",
+				zap.String("addr", f.addr),
+				zap.Error(err),
+			)
 		}
 	}()
 
@@ -113,8 +117,12 @@ func (f *Forwarder) forward(downstream net.Conn) {
 		defer g.Done()
 		defer upstream.Close()
 		_, err := io.Copy(upstream, downstream)
-		if err != nil && !errors.Is(err, io.EOF) {
-			f.logger.Debug("failure to copy from downstream to upstream", zap.String("addr", f.addr), zap.Error(err))
+		if err != nil {
+			f.logger.Debug(
+				"copy to upstream closed",
+				zap.String("addr", f.addr),
+				zap.Error(err),
+			)
 		}
 	}()
 

--- a/forward/forwarder.go
+++ b/forward/forwarder.go
@@ -88,16 +88,24 @@ func (f *Forwarder) forwardConn(conn net.Conn) {
 		defer g.Done()
 		defer conn.Close()
 		_, err := io.Copy(conn, upstream)
-		if err != nil && !errors.Is(err, io.EOF) {
-			f.logger.Debug("failure to copy from upstream to connection", zap.String("endpoint-id", f.endpointID), zap.Error(err))
+		if err != nil {
+			f.logger.Debug(
+				"copy to conn closed",
+				zap.String("endpoint-id", f.endpointID),
+				zap.Error(err),
+			)
 		}
 	}()
 	go func() {
 		defer g.Done()
 		defer upstream.Close()
 		_, err := io.Copy(upstream, conn)
-		if err != nil && !errors.Is(err, io.EOF) {
-			f.logger.Debug("failure to copy from connection to upstream", zap.String("endpoint-id", f.endpointID), zap.Error(err))
+		if err != nil {
+			f.logger.Debug(
+				"copy to upstream closed",
+				zap.String("endpoint-id", f.endpointID),
+				zap.Error(err),
+			)
 		}
 	}()
 	g.Wait()

--- a/forward/forwarder.go
+++ b/forward/forwarder.go
@@ -89,7 +89,7 @@ func (f *Forwarder) forwardConn(conn net.Conn) {
 		defer conn.Close()
 		_, err := io.Copy(conn, upstream)
 		if err != nil && !errors.Is(err, io.EOF) {
-			f.logger.Error("failure to copy from upstream to connection", zap.String("endpoint-id", f.endpointID), zap.Error(err))
+			f.logger.Debug("failure to copy from upstream to connection", zap.String("endpoint-id", f.endpointID), zap.Error(err))
 		}
 	}()
 	go func() {
@@ -97,7 +97,7 @@ func (f *Forwarder) forwardConn(conn net.Conn) {
 		defer upstream.Close()
 		_, err := io.Copy(upstream, conn)
 		if err != nil && !errors.Is(err, io.EOF) {
-			f.logger.Error("failure to copy from connection to upstream", zap.String("endpoint-id", f.endpointID), zap.Error(err))
+			f.logger.Debug("failure to copy from connection to upstream", zap.String("endpoint-id", f.endpointID), zap.Error(err))
 		}
 	}()
 	g.Wait()

--- a/server/proxy/tcpproxy.go
+++ b/server/proxy/tcpproxy.go
@@ -96,7 +96,7 @@ func (p *TCPProxy) forward(upstream net.Conn, downstream net.Conn) {
 		defer upstream.Close()
 		_, err := io.Copy(upstream, downstream)
 		if err != nil && !errors.Is(err, io.EOF) {
-			p.logger.Error("failure to copy from downstream to upstream", zap.Error(err))
+			p.logger.Debug("failure to copy from downstream to upstream", zap.Error(err))
 		}
 	}()
 	go func() {
@@ -104,7 +104,7 @@ func (p *TCPProxy) forward(upstream net.Conn, downstream net.Conn) {
 		defer downstream.Close()
 		_, err := io.Copy(downstream, upstream)
 		if err != nil && !errors.Is(err, io.EOF) {
-			p.logger.Error("failure to copy from upstream to downstream", zap.Error(err))
+			p.logger.Debug("failure to copy from upstream to downstream", zap.Error(err))
 		}
 	}()
 	wg.Wait()

--- a/server/proxy/tcpproxy.go
+++ b/server/proxy/tcpproxy.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -95,16 +94,16 @@ func (p *TCPProxy) forward(upstream net.Conn, downstream net.Conn) {
 		defer wg.Done()
 		defer upstream.Close()
 		_, err := io.Copy(upstream, downstream)
-		if err != nil && !errors.Is(err, io.EOF) {
-			p.logger.Debug("failure to copy from downstream to upstream", zap.Error(err))
+		if err != nil {
+			p.logger.Debug("copy to upstream closed", zap.Error(err))
 		}
 	}()
 	go func() {
 		defer wg.Done()
 		defer downstream.Close()
 		_, err := io.Copy(downstream, upstream)
-		if err != nil && !errors.Is(err, io.EOF) {
-			p.logger.Debug("failure to copy from upstream to downstream", zap.Error(err))
+		if err != nil {
+			p.logger.Debug("copy to downstream closed", zap.Error(err))
 		}
 	}()
 	wg.Wait()


### PR DESCRIPTION
Adds debug logs when io.Copy returns an error when forwarding traffic
between two TCP connections.
