### PR TITLE
proxy: only apply proxy timeout to non-websocket requests

### DIFF
--- a/agent/reverseproxy/reverseproxy.go
+++ b/agent/reverseproxy/reverseproxy.go
@@ -43,7 +43,7 @@ func NewReverseProxy(conf config.ListenerConfig, logger log.Logger) *ReverseProx
 }
 
 func (p *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if p.timeout != 0 {
+	if p.timeout != 0 && r.Header.Get("upgrade") != "websocket" {
 		ctx, cancel := context.WithTimeout(r.Context(), p.timeout)
 		defer cancel()
 

--- a/server/proxy/httpproxy.go
+++ b/server/proxy/httpproxy.go
@@ -92,7 +92,7 @@ func (p *HTTPProxy) ServeHTTPWithUpstream(
 	endpointID string,
 	upstream upstream.Upstream,
 ) {
-	if p.timeout != 0 {
+	if p.timeout != 0 && r.Header.Get("upgrade") != "websocket" {
 		ctx, cancel := context.WithTimeout(r.Context(), p.timeout)
 		defer cancel()
 


### PR DESCRIPTION
Updates the HTTP proxy (both server and agent) to only apply the timeout to non-websocket requests.

This is a fairly quick fix to ensure long lived TCP and WebSocket connections work. In the future will try and apply the timeout based on the initial request response (i.e. if the request has been hijacked don't apply a timeout) instead of request header.

Fixes https://github.com/andydunstall/piko/issues/147.