### PR TITLE
tcp: Fix protocol configuration loading

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -104,7 +104,7 @@ func (c *ListenerConfig) Validate() error {
 		if _, ok := c.URL(); !ok {
 			return fmt.Errorf("invalid addr")
 		}
-	} else if c.Protocol != ListenerProtocolTCP {
+	} else if c.Protocol == ListenerProtocolTCP {
 		if _, ok := c.Host(); !ok {
 			return fmt.Errorf("invalid addr")
 		}


### PR DESCRIPTION
I'm getting started with Piko and tried to configure a TCP Listener in the configuration file.

```
listeners:
  - endpoint_id: my-ssh
    addr: '22'
    protocol: tcp
    timeout: 15s
```

This returns an error `config: listener: my-ssh: unsupported protocol`.

When trying with `protocol: TCP` (or even `protocol: asdf`), it continues loading, the upstream is created but I was unable to connect. It looks like the TCP configuration was not loaded correctly.