### PR TITLE
feat: introduce InsecureSkipVerify to listener config

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -29,6 +29,9 @@ type ListenerConfig struct {
 	// Addr is the address of the upstream service to forward to.
 	Addr string `json:"addr" yaml:"addr"`
 
+	// InsecureSkipVerify allows the proxy to ignore certificates on HTTPS connections.
+	InsecureSkipVerify bool `json:"insecure_skip_verify" yaml:"insecure_skip_verify"`
+
 	// Protocol is the protocol to listen on. Supports "http" and "tcp".
 	// Defaults to "http".
 	Protocol ListenerProtocol `json:"protocol" yaml:"protocol"`

--- a/agent/reverseproxy/reverseproxy.go
+++ b/agent/reverseproxy/reverseproxy.go
@@ -36,8 +36,8 @@ func NewReverseProxy(conf config.ListenerConfig, logger log.Logger) *ReverseProx
 
 	transport := http.DefaultTransport
 	if tpt, ok := transport.(*http.Transport); ok {
-        tpt.TLSClientConfig, _ = conf.TLS.Load()
-    }
+		tpt.TLSClientConfig, _ = conf.TLS.Load()
+	}
 
 	proxy.Transport = transport
 

--- a/agent/reverseproxy/reverseproxy.go
+++ b/agent/reverseproxy/reverseproxy.go
@@ -2,6 +2,7 @@ package reverseproxy
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -37,6 +38,13 @@ func NewReverseProxy(conf config.ListenerConfig, logger log.Logger) *ReverseProx
 		proxy:   proxy,
 		timeout: conf.Timeout,
 		logger:  logger,
+	}
+	if conf.InsecureSkipVerify {
+		proxy.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
 	}
 	proxy.ErrorHandler = rp.errorHandler
 	return rp


### PR DESCRIPTION
We want to tunnel services, some of which are _secured_ with HTTPS but self-signed certificates, and over which we have limited control. This PR adds a `insecure_skip_verify` configuration in the listener that would allow the agent to proxy such services.

```
listeners:
    - endpoint_id: self-signed-api
      addr: https://some-server:8443
      protocol: http
      insecure_skip_verify: true
      timeout: 15s
```

This configuration name is based on the `InsecureSkipVerify` configuration of the TLS Transport configuration and reflects the fact that this is insecure and should be a _last resort_.

I'm open to any comment or other suggestions if I missed another way of dealing with that.