### PR TITLE
agent: add listener tls client config

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -82,6 +82,12 @@ func (c *ListenerConfig) URL() (*url.URL, bool) {
 		}, true
 	}
 
+	// URL.
+	u, err := url.Parse(c.Addr)
+	if err == nil && u.Scheme != "" && u.Host != "" {
+		return u, true
+	}
+
 	// Host and port.
 	host, portStr, err := net.SplitHostPort(c.Addr)
 	if err == nil {
@@ -89,12 +95,6 @@ func (c *ListenerConfig) URL() (*url.URL, bool) {
 			Scheme: "http",
 			Host:   net.JoinHostPort(host, portStr),
 		}, true
-	}
-
-	// URL.
-	u, err := url.Parse(c.Addr)
-	if err == nil && u.Scheme != "" && u.Host != "" {
-		return u, true
 	}
 
 	return nil, false

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -41,13 +41,27 @@ func TestListenerConfig_URL(t *testing.T) {
 			},
 		},
 		{
+			addr: "https://google.com:443",
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "google.com:443",
+			},
+		},
+		{
+			addr: "https://google.com",
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "google.com",
+			},
+		},
+		{
 			addr: "invalid",
 			ok:   false,
 		},
 	}
 
 	for _, tt := range tests {
-		tt := tt // for t.Parallel
+		tt := tt
 		t.Run(tt.addr, func(t *testing.T) {
 			conf := &ListenerConfig{Addr: tt.addr}
 			u, ok := conf.URL()


### PR DESCRIPTION
Fixes https://github.com/andydunstall/piko/issues/185

Adds TLS client configuration to agent listener configuration