### PR TITLE
server: remove tls config enabled

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -170,10 +170,6 @@ host name in that certificate.`,
 }
 
 func (c *TLSConfig) Load() (*tls.Config, error) {
-	if c.RootCAs == "" && !c.InsecureSkipVerify {
-		return nil, nil
-	}
-
 	tlsConfig := &tls.Config{}
 
 	if c.RootCAs != "" {

--- a/forward/config/config.go
+++ b/forward/config/config.go
@@ -99,10 +99,6 @@ host name in that certificate.`,
 }
 
 func (c *TLSConfig) Load() (*tls.Config, error) {
-	if c.RootCAs == "" && !c.InsecureSkipVerify {
-		return nil, nil
-	}
-
 	tlsConfig := &tls.Config{}
 
 	if c.RootCAs != "" {

--- a/pikotest/cluster/node.go
+++ b/pikotest/cluster/node.go
@@ -46,10 +46,6 @@ func NewNode(opts ...Option) *Node {
 	// file.
 	var rootCAPool *x509.CertPool
 	if options.tls {
-		conf.Proxy.TLS.Enabled = true
-		conf.Upstream.TLS.Enabled = true
-		conf.Admin.TLS.Enabled = true
-
 		pool, cert, err := testutil.LocalTLSServerCert()
 		if err != nil {
 			panic("tls cert: " + err.Error())

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -45,7 +45,6 @@ proxy:
     issuer: my-issuer
 
   tls:
-    enabled: true
     cert: /piko/cert.pem
     key: /piko/key.pem
 
@@ -61,7 +60,6 @@ upstream:
     issuer: my-issuer
 
   tls:
-    enabled: true
     cert: /piko/cert.pem
     key: /piko/key.pem
 
@@ -77,7 +75,6 @@ admin:
     issuer: my-issuer
 
   tls:
-    enabled: true
     cert: /piko/cert.pem
     key: /piko/key.pem
 
@@ -139,9 +136,8 @@ grace_period: 2m
 				Issuer:         "my-issuer",
 			},
 			TLS: TLSConfig{
-				Enabled: true,
-				Cert:    "/piko/cert.pem",
-				Key:     "/piko/key.pem",
+				Cert: "/piko/cert.pem",
+				Key:  "/piko/key.pem",
 			},
 		},
 		Upstream: UpstreamConfig{
@@ -155,9 +151,8 @@ grace_period: 2m
 				Issuer:         "my-issuer",
 			},
 			TLS: TLSConfig{
-				Enabled: true,
-				Cert:    "/piko/cert.pem",
-				Key:     "/piko/key.pem",
+				Cert: "/piko/cert.pem",
+				Key:  "/piko/key.pem",
 			},
 		},
 		Admin: AdminConfig{
@@ -171,9 +166,8 @@ grace_period: 2m
 				Issuer:         "my-issuer",
 			},
 			TLS: TLSConfig{
-				Enabled: true,
-				Cert:    "/piko/cert.pem",
-				Key:     "/piko/key.pem",
+				Cert: "/piko/cert.pem",
+				Key:  "/piko/key.pem",
 			},
 		},
 		Cluster: ClusterConfig{
@@ -224,7 +218,6 @@ func TestConfig_LoadFlags(t *testing.T) {
 		"--proxy.auth.ecdsa-public-key", "ecdsa-public-key",
 		"--proxy.auth.audience", "my-audience",
 		"--proxy.auth.issuer", "my-issuer",
-		"--proxy.tls.enabled",
 		"--proxy.tls.cert", "/piko/cert.pem",
 		"--proxy.tls.key", "/piko/key.pem",
 		"--upstream.bind-addr", "10.15.104.25:8001",
@@ -234,7 +227,6 @@ func TestConfig_LoadFlags(t *testing.T) {
 		"--upstream.auth.ecdsa-public-key", "ecdsa-public-key",
 		"--upstream.auth.audience", "my-audience",
 		"--upstream.auth.issuer", "my-issuer",
-		"--upstream.tls.enabled",
 		"--upstream.tls.cert", "/piko/cert.pem",
 		"--upstream.tls.key", "/piko/key.pem",
 		"--admin.bind-addr", "10.15.104.25:8002",
@@ -244,7 +236,6 @@ func TestConfig_LoadFlags(t *testing.T) {
 		"--admin.auth.ecdsa-public-key", "ecdsa-public-key",
 		"--admin.auth.audience", "my-audience",
 		"--admin.auth.issuer", "my-issuer",
-		"--admin.tls.enabled",
 		"--admin.tls.cert", "/piko/cert.pem",
 		"--admin.tls.key", "/piko/key.pem",
 		"--cluster.node-id", "my-node",
@@ -289,9 +280,8 @@ func TestConfig_LoadFlags(t *testing.T) {
 				Issuer:         "my-issuer",
 			},
 			TLS: TLSConfig{
-				Enabled: true,
-				Cert:    "/piko/cert.pem",
-				Key:     "/piko/key.pem",
+				Cert: "/piko/cert.pem",
+				Key:  "/piko/key.pem",
 			},
 		},
 		Upstream: UpstreamConfig{
@@ -305,9 +295,8 @@ func TestConfig_LoadFlags(t *testing.T) {
 				Issuer:         "my-issuer",
 			},
 			TLS: TLSConfig{
-				Enabled: true,
-				Cert:    "/piko/cert.pem",
-				Key:     "/piko/key.pem",
+				Cert: "/piko/cert.pem",
+				Key:  "/piko/key.pem",
 			},
 		},
 		Admin: AdminConfig{
@@ -321,9 +310,8 @@ func TestConfig_LoadFlags(t *testing.T) {
 				Issuer:         "my-issuer",
 			},
 			TLS: TLSConfig{
-				Enabled: true,
-				Cert:    "/piko/cert.pem",
-				Key:     "/piko/key.pem",
+				Cert: "/piko/cert.pem",
+				Key:  "/piko/key.pem",
 			},
 		},
 		Cluster: ClusterConfig{

--- a/server/config/tls.go
+++ b/server/config/tls.go
@@ -8,13 +8,12 @@ import (
 )
 
 type TLSConfig struct {
-	Enabled bool   `json:"enabled" yaml:"enabled"`
-	Cert    string `json:"cert" yaml:"cert"`
-	Key     string `json:"key" yaml:"key"`
+	Cert string `json:"cert" yaml:"cert"`
+	Key  string `json:"key" yaml:"key"`
 }
 
 func (c *TLSConfig) Validate() error {
-	if !c.Enabled {
+	if !c.enabled() {
 		return nil
 	}
 
@@ -30,21 +29,14 @@ func (c *TLSConfig) Validate() error {
 func (c *TLSConfig) RegisterFlags(fs *pflag.FlagSet, prefix string) {
 	prefix += ".tls."
 
-	fs.BoolVar(
-		&c.Enabled,
-		prefix+"enabled",
-		c.Enabled,
-		`
-Whether to enable TLS on the listener.
-
-If enabled must configure the cert and key.`,
-	)
 	fs.StringVar(
 		&c.Cert,
 		prefix+"cert",
 		c.Cert,
 		`
-Path to the PEM encoded certificate file.`,
+Path to the PEM encoded certificate file.
+
+If given the server will listen on TLS`,
 	)
 	fs.StringVar(
 		&c.Key,
@@ -56,7 +48,7 @@ Path to the PEM encoded key file.`,
 }
 
 func (c *TLSConfig) Load() (*tls.Config, error) {
-	if !c.Enabled {
+	if !c.enabled() {
 		return nil, nil
 	}
 
@@ -68,4 +60,8 @@ func (c *TLSConfig) Load() (*tls.Config, error) {
 	tlsConfig.Certificates = []tls.Certificate{cert}
 
 	return tlsConfig, nil
+}
+
+func (c *TLSConfig) enabled() bool {
+	return c.Cert != "" || c.Key != ""
 }


### PR DESCRIPTION
Removes the redundant 'tls.enabled' configuration, as it can be inferred from whether the cert/key are given.