### PR TITLE
backoff: fix enforcing max backoff

### DIFF
--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -56,6 +56,9 @@ func (b *Backoff) nextWait() time.Duration {
 	} else {
 		backoff = b.lastBackoff * 2
 	}
+	if backoff > b.maxBackoff {
+		backoff = b.maxBackoff
+	}
 
 	jitterMultipler := 1.0 + (rand.Float64() * 0.1)
 	return time.Duration(float64(backoff) * jitterMultipler)


### PR DESCRIPTION
The Piko client uses backoff with jitter to avoid overloading the server when reconnecting, however the client wasn't enforcing max backoff meaning it could grow far too large...