### PR TITLE
server: add upstream multi-tenant auth support

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -232,6 +232,8 @@ type ConnectConfig struct {
 	Token string `json:"token" yaml:"token"`
 
 	// TenantID is the ID of the agent tenant (optional).
+	//
+	// Experimental.
 	TenantID string `json:"tenant_id" yaml:"tenant_id"`
 
 	// Timeout is the timeout attempting to connect to the Piko server on

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -226,10 +226,13 @@ func (c *TLSConfig) Load() (*tls.Config, error) {
 
 type ConnectConfig struct {
 	// URL is the Piko server URL to connect to.
-	URL string
+	URL string `json:"url" yaml:"url"`
 
 	// Token is a token to authenticate with the Piko server.
-	Token string
+	Token string `json:"token" yaml:"token"`
+
+	// TenantID is the ID of the agent tenant (optional).
+	TenantID string `json:"tenant_id" yaml:"tenant_id"`
 
 	// Timeout is the timeout attempting to connect to the Piko server on
 	// boot.
@@ -270,6 +273,17 @@ Piko server 'upstream' port.`,
 		c.Token,
 		`
 Token is a token to authenticate with the Piko server.`,
+	)
+
+	fs.StringVar(
+		&c.TenantID,
+		"connect.tenant-id",
+		c.TenantID,
+		`
+Tenant ID of the agent.
+
+Tenants can be used to configure different authentication mechanisms and keys
+for different upstream services.`,
 	)
 
 	fs.DurationVar(

--- a/cli/agent/command.go
+++ b/cli/agent/command.go
@@ -116,6 +116,7 @@ func runAgent(conf *config.Config, logger log.Logger) error {
 	upstream := &client.Upstream{
 		URL:       connectURL,
 		Token:     conf.Connect.Token,
+		TenantID:  conf.Connect.TenantID,
 		TLSConfig: connectTLSConfig,
 		Logger:    logger.WithSubsystem("client"),
 	}

--- a/client/upstream.go
+++ b/client/upstream.go
@@ -41,6 +41,12 @@ type Upstream struct {
 	// Defaults to no authentication.
 	Token string
 
+	// TenantID configures the tenant to authenticate the listener with the
+	// Piko server.
+	//
+	// Defaults to no tenant (optional).
+	TenantID string
+
 	// TLSConfig specifies the TLS configuration to use with the Piko server.
 	//
 	// If nil, the default configuration is used.
@@ -110,6 +116,7 @@ func (u *Upstream) connect(ctx context.Context, endpointID string) (*yamux.Sessi
 			ctx,
 			url,
 			websocket.WithToken(u.Token),
+			websocket.WithTenantID(u.TenantID),
 			websocket.WithTLSConfig(u.TLSConfig),
 		)
 		if err == nil {

--- a/client/upstream.go
+++ b/client/upstream.go
@@ -45,6 +45,8 @@ type Upstream struct {
 	// Piko server.
 	//
 	// Defaults to no tenant (optional).
+	//
+	// Experimental.
 	TenantID string
 
 	// TLSConfig specifies the TLS configuration to use with the Piko server.

--- a/pkg/auth/multi_tenant_verifier.go
+++ b/pkg/auth/multi_tenant_verifier.go
@@ -1,0 +1,42 @@
+package auth
+
+type MultiTenantVerifier struct {
+	defaultVerifier Verifier
+	tenantVerifiers map[string]Verifier
+}
+
+func NewMultiTenantVerifier(
+	defaultVerifier Verifier,
+	tenantVerifiers map[string]Verifier,
+) *MultiTenantVerifier {
+	return &MultiTenantVerifier{
+		defaultVerifier: defaultVerifier,
+		tenantVerifiers: tenantVerifiers,
+	}
+}
+
+func (v *MultiTenantVerifier) Verify(token string, tenantID string) (*Token, error) {
+	if tenantID == "" {
+		if len(v.tenantVerifiers) != 0 {
+			// If tenants are configured, the default tenant is disabled.
+			return nil, ErrUnknownTenant
+		}
+		return v.defaultVerifier.Verify(token)
+	}
+
+	if v.tenantVerifiers == nil {
+		return nil, ErrUnknownTenant
+	}
+
+	verifier, ok := v.tenantVerifiers[tenantID]
+	if !ok {
+		return nil, ErrUnknownTenant
+	}
+
+	t, err := verifier.Verify(token)
+	if err != nil {
+		return nil, err
+	}
+	t.TenantID = tenantID
+	return t, nil
+}

--- a/pkg/auth/multi_tenant_verifier_test.go
+++ b/pkg/auth/multi_tenant_verifier_test.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiTenantVerifier(t *testing.T) {
+	defaultSecretKey := generateTestHSKey(t)
+	tenant1SecretKey := generateTestHSKey(t)
+	tenant2SecretKey := generateTestHSKey(t)
+
+	endpointClaims := JWTClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+
+	defaultVerifier := NewJWTVerifier(&LoadedConfig{
+		HMACSecretKey: defaultSecretKey,
+	})
+	tenantVerifiers := map[string]Verifier{
+		"tenant-1": NewJWTVerifier(&LoadedConfig{
+			HMACSecretKey: tenant1SecretKey,
+		}),
+		"tenant-2": NewJWTVerifier(&LoadedConfig{
+			HMACSecretKey: tenant2SecretKey,
+		}),
+	}
+	verifier := NewMultiTenantVerifier(defaultVerifier, tenantVerifiers)
+
+	t.Run("default", func(t *testing.T) {
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, endpointClaims)
+		tokenString, err := token.SignedString([]byte(defaultSecretKey))
+		assert.NoError(t, err)
+
+		_, err = verifier.Verify(tokenString, "")
+		assert.Equal(t, ErrUnknownTenant, err)
+	})
+
+	t.Run("tenant", func(t *testing.T) {
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, endpointClaims)
+		tokenString, err := token.SignedString([]byte(tenant1SecretKey))
+		assert.NoError(t, err)
+
+		parsedToken, err := verifier.Verify(tokenString, "tenant-1")
+		assert.NoError(t, err)
+
+		assert.Equal(t, parsedToken.TenantID, "tenant-1")
+	})
+
+	// Tests tenant 1 using tenants 2 key.
+	t.Run("incorrect key", func(t *testing.T) {
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, endpointClaims)
+		tokenString, err := token.SignedString([]byte(tenant2SecretKey))
+		assert.NoError(t, err)
+
+		_, err = verifier.Verify(tokenString, "tenant-1")
+		assert.Equal(t, ErrInvalidToken, err)
+	})
+
+	t.Run("unknown tenant", func(t *testing.T) {
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, endpointClaims)
+		tokenString, err := token.SignedString([]byte(defaultSecretKey))
+		assert.NoError(t, err)
+
+		_, err = verifier.Verify(tokenString, "unknown")
+		assert.Equal(t, ErrUnknownTenant, err)
+	})
+}

--- a/pkg/auth/verifier.go
+++ b/pkg/auth/verifier.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	ErrInvalidToken = errors.New("invalid token")
-	ErrExpiredToken = errors.New("expired token")
+	ErrInvalidToken  = errors.New("invalid token")
+	ErrExpiredToken  = errors.New("expired token")
+	ErrUnknownTenant = errors.New("unknown tenant")
 )
 
 // Token represents an authenticated Piko token.
@@ -21,6 +22,9 @@ type Token struct {
 	// to access (either connect to or listen on). If empty then all endpoints
 	// are allowed.
 	Endpoints []string
+
+	// TenantID is the ID of the client tenant.
+	TenantID string
 }
 
 // EndpointPermitted returns whether the token it permitted to access the

--- a/pkg/websocket/conn.go
+++ b/pkg/websocket/conn.go
@@ -49,6 +49,7 @@ func (e *RetryableError) Error() string {
 
 type dialOptions struct {
 	token     string
+	tenantID  string
 	tlsConfig *tls.Config
 }
 
@@ -64,6 +65,16 @@ func (o tokenOption) apply(opts *dialOptions) {
 
 func WithToken(token string) DialOption {
 	return tokenOption(token)
+}
+
+type tenantIDOption string
+
+func (o tenantIDOption) apply(opts *dialOptions) {
+	opts.tenantID = string(o)
+}
+
+func WithTenantID(tenantID string) DialOption {
+	return tenantIDOption(tenantID)
 }
 
 type tlsConfigOption struct {
@@ -112,6 +123,9 @@ func Dial(ctx context.Context, url string, opts ...DialOption) (*Conn, error) {
 	header := make(http.Header)
 	if options.token != "" {
 		header.Set("Authorization", "Bearer "+options.token)
+	}
+	if options.tenantID != "" {
+		header.Set("x-piko-tenant-id", options.tenantID)
 	}
 
 	wsConn, resp, err := dialer.DialContext(

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -43,7 +43,7 @@ type Server struct {
 func NewServer(
 	clusterState *cluster.State,
 	registry *prometheus.Registry,
-	verifier auth.Verifier,
+	verifier *auth.MultiTenantVerifier,
 	tlsConfig *tls.Config,
 	logger log.Logger,
 ) *Server {

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -235,14 +235,14 @@ func TestServer_Authentication(t *testing.T) {
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 
-		verifier := &fakeVerifier{
+		verifier := auth.NewMultiTenantVerifier(&fakeVerifier{
 			handler: func(token string) (*auth.Token, error) {
 				assert.Equal(t, "123", token)
 				return &auth.Token{
 					Expiry: time.Now().Add(time.Hour),
 				}, nil
 			},
-		}
+		}, nil)
 
 		s := NewServer(
 			nil,
@@ -272,12 +272,12 @@ func TestServer_Authentication(t *testing.T) {
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 
-		verifier := &fakeVerifier{
+		verifier := auth.NewMultiTenantVerifier(&fakeVerifier{
 			handler: func(token string) (*auth.Token, error) {
 				assert.Equal(t, "123", token)
 				return nil, auth.ErrInvalidToken
 			},
-		}
+		}, nil)
 
 		s := NewServer(
 			nil,

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -68,6 +68,14 @@ upstream:
     cert: /piko/cert.pem
     key: /piko/key.pem
 
+  tenants:
+    - id: tenant-1
+      auth:
+        hmac_secret_key: hmac-secret-key
+    - id: tenant-2
+      auth:
+        rsa_public_key: rsa-public-key
+
 admin:
   bind_addr: 10.15.104.25:8002
   advertise_addr: 1.2.3.4:8002
@@ -163,6 +171,20 @@ grace_period: 2m
 			TLS: TLSConfig{
 				Cert: "/piko/cert.pem",
 				Key:  "/piko/key.pem",
+			},
+			Tenants: []TenantConfig{
+				{
+					ID: "tenant-1",
+					Auth: auth.Config{
+						HMACSecretKey: "hmac-secret-key",
+					},
+				},
+				{
+					ID: "tenant-2",
+					Auth: auth.Config{
+						RSAPublicKey: "rsa-public-key",
+					},
+				},
 			},
 		},
 		Admin: AdminConfig{

--- a/server/proxy/server.go
+++ b/server/proxy/server.go
@@ -33,7 +33,7 @@ func NewServer(
 	upstreams upstream.Manager,
 	proxyConfig config.ProxyConfig,
 	registry *prometheus.Registry,
-	verifier auth.Verifier,
+	verifier *auth.MultiTenantVerifier,
 	tlsConfig *tls.Config,
 	logger log.Logger,
 ) *Server {

--- a/server/proxy/server_test.go
+++ b/server/proxy/server_test.go
@@ -430,7 +430,7 @@ func TestServer_Authentication(t *testing.T) {
 		))
 		defer upstreamServer.Close()
 
-		verifier := &fakeVerifier{
+		verifier := auth.NewMultiTenantVerifier(&fakeVerifier{
 			handler: func(token string) (*auth.Token, error) {
 				assert.Equal(t, "123", token)
 				return &auth.Token{
@@ -438,7 +438,7 @@ func TestServer_Authentication(t *testing.T) {
 					Endpoints: []string{"my-endpoint"},
 				}, nil
 			},
-		}
+		}, nil)
 
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
@@ -484,7 +484,7 @@ func TestServer_Authentication(t *testing.T) {
 	})
 
 	t.Run("endpoint not permitted", func(t *testing.T) {
-		verifier := &fakeVerifier{
+		verifier := auth.NewMultiTenantVerifier(&fakeVerifier{
 			handler: func(token string) (*auth.Token, error) {
 				assert.Equal(t, "123", token)
 				return &auth.Token{
@@ -492,7 +492,7 @@ func TestServer_Authentication(t *testing.T) {
 					Endpoints: []string{"my-endpoint"},
 				}, nil
 			},
-		}
+		}, nil)
 
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
@@ -544,14 +544,14 @@ func TestServer_Authentication(t *testing.T) {
 		))
 		defer upstreamServer.Close()
 
-		verifier := &fakeVerifier{
+		verifier := auth.NewMultiTenantVerifier(&fakeVerifier{
 			handler: func(token string) (*auth.Token, error) {
 				assert.Equal(t, "123", token)
 				return &auth.Token{
 					Expiry: time.Now().Add(time.Hour),
 				}, nil
 			},
-		}
+		}, nil)
 
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
@@ -597,12 +597,12 @@ func TestServer_Authentication(t *testing.T) {
 	})
 
 	t.Run("unauthenticated", func(t *testing.T) {
-		verifier := &fakeVerifier{
+		verifier := auth.NewMultiTenantVerifier(&fakeVerifier{
 			handler: func(token string) (*auth.Token, error) {
 				assert.Equal(t, "123", token)
 				return nil, auth.ErrInvalidToken
 			},
-		}
+		}, nil)
 
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)

--- a/server/upstream/server_test.go
+++ b/server/upstream/server_test.go
@@ -119,7 +119,7 @@ func TestServer_Authentication(t *testing.T) {
 
 		manager := newFakeManager()
 
-		verifier := &fakeVerifier{
+		verifier := auth.NewMultiTenantVerifier(&fakeVerifier{
 			handler: func(token string) (*auth.Token, error) {
 				assert.Equal(t, "123", token)
 				return &auth.Token{
@@ -127,7 +127,7 @@ func TestServer_Authentication(t *testing.T) {
 					Endpoints: []string{"my-endpoint"},
 				}, nil
 			},
-		}
+		}, nil)
 
 		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, log.NewNopLogger())
 		go func() {
@@ -157,7 +157,7 @@ func TestServer_Authentication(t *testing.T) {
 
 		manager := newFakeManager()
 
-		verifier := &fakeVerifier{
+		verifier := auth.NewMultiTenantVerifier(&fakeVerifier{
 			handler: func(token string) (*auth.Token, error) {
 				assert.Equal(t, "123", token)
 				return &auth.Token{
@@ -166,7 +166,7 @@ func TestServer_Authentication(t *testing.T) {
 					Endpoints: []string{"my-endpoint"},
 				}, nil
 			},
-		}
+		}, nil)
 
 		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, log.NewNopLogger())
 		go func() {
@@ -197,7 +197,7 @@ func TestServer_Authentication(t *testing.T) {
 
 		manager := newFakeManager()
 
-		verifier := &fakeVerifier{
+		verifier := auth.NewMultiTenantVerifier(&fakeVerifier{
 			handler: func(token string) (*auth.Token, error) {
 				assert.Equal(t, "123", token)
 				return &auth.Token{
@@ -205,7 +205,7 @@ func TestServer_Authentication(t *testing.T) {
 					Endpoints: []string{"foo"},
 				}, nil
 			},
-		}
+		}, nil)
 
 		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, log.NewNopLogger())
 		go func() {
@@ -229,14 +229,14 @@ func TestServer_Authentication(t *testing.T) {
 
 		manager := newFakeManager()
 
-		verifier := &fakeVerifier{
+		verifier := auth.NewMultiTenantVerifier(&fakeVerifier{
 			handler: func(token string) (*auth.Token, error) {
 				assert.Equal(t, "123", token)
 				return &auth.Token{
 					Expiry: time.Now().Add(time.Hour),
 				}, nil
 			},
-		}
+		}, nil)
 
 		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, log.NewNopLogger())
 		go func() {
@@ -266,12 +266,12 @@ func TestServer_Authentication(t *testing.T) {
 
 		manager := newFakeManager()
 
-		verifier := &fakeVerifier{
+		verifier := auth.NewMultiTenantVerifier(&fakeVerifier{
 			handler: func(token string) (*auth.Token, error) {
 				assert.Equal(t, "123", token)
 				return nil, auth.ErrInvalidToken
 			},
-		}
+		}, nil)
 
 		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, log.NewNopLogger())
 		go func() {


### PR DESCRIPTION
Fixes https://github.com/andydunstall/piko/issues/179.

Adds support for upstream multi-tenant authentication, such as:
```
upstream:
  auth:
    hmac_secret_key: admin-secret

  tenants:
    - id: tenant-1
      auth:
        hmac_secret_key: tenant-1-secret
    - id: tenant-2
      auth:
        hmac_secret_key: tenant-2-secret
    - id: tenant-3
      auth:
        hmac_secret_key: tenant-3-secret
```

This includes adding agent support for specifying a tenant ID, with `--connect.tenant-id`.