### PR TITLE
server: add missing disable disconnect on expiry yaml tag

### DIFF
--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	// token expires.
 	//
 	// Piko still verifies the token expiry when the client first connects.
-	DisableDisconnectOnExpiry bool `json:"disable_disconnect_on_expiry"`
+	DisableDisconnectOnExpiry bool `json:"disable_disconnect_on_expiry" yaml:"disable_disconnect_on_expiry"`
 }
 
 // LoadedConfig is the same as Config except it parses the RSA and ECDSA keys.


### PR DESCRIPTION
As it stands, the flag is currently available on the JSON parser, but neither of the config options work. I noticed we were missing the `yaml` tag for the new property, which now allows for the config to be properly parsed

### Current latest v0.6.5 behaviour

server.json:

```json
{
    "proxy": {
        "bind_addr": ":7200",
        "access_log": true
    },
    "upstream": {
        "bind_addr": ":7300",
        "auth": {
            "disable_disconnect_on_expiry": true
        }
    },
    "admin": {
        "bind_addr": ":7400"
    },
    "cluster": {
        "gossip": {
            "bind_addr": ":7500"
        }
    },
    "log": {
        "level": "info"
    }
}
```

server.yaml

```yaml
proxy:
  bind_addr: ":7200"
  access_log: true

upstream:
  bind_addr: ":7300"
  auth:
    disable_disconnect_on_expiry: true

admin:
  bind_addr: ":7400"

cluster:
  node_id_prefix: "sombra-proxy"
  gossip:
    bind_addr: ":7500"

log:
  level: info
```

Errors:

```bash
$ ./piko server start --config.path server.json                                                                                                                                                                                                                   
parse config: server.json: yaml: unmarshal errors:
  line 9: field disable_disconnect_on_expiry not found in type auth.Config
$ ./piko server start --config.path server.yaml                                                                                                                                                                                                                 
parse config: server.yaml: yaml: unmarshal errors:
  line 8: field disable_disconnect_on_expiry not found in type auth.Config
```

### After applying this fix

Run output:

```bash
$ rm ./bin/piko && make && ./bin/piko server start --config.path /tmp/piko-server.yaml 
fatal: No names found, cannot describe anything.
mkdir -p bin
go build -ldflags="-X github.com/andydunstall/piko/pkg/build.Version=" -o bin/piko main.go
{"level":"info","ts":"2024-12-23T20:32:04.94Z","subsystem":"server","msg":"starting piko server","node-id":"sombra-proxyb2ctbbl","version":""}
{"level":"info","ts":"2024-12-23T20:32:04.94Z","subsystem":"admin","msg":"starting admin server","addr":"[::]:7400"}
{"level":"info","ts":"2024-12-23T20:32:04.943Z","subsystem":"gossip","msg":"starting gossip","node-id":"sombra-proxyb2ctbbl","bind-addr":":7500","advertise-addr":"10.0.0.65:7500"}
{"level":"info","ts":"2024-12-23T20:32:04.943Z","subsystem":"proxy","msg":"starting proxy server","addr":"[::]:7200"}
{"level":"info","ts":"2024-12-23T20:32:04.943Z","subsystem":"upstream","msg":"starting upstream server","addr":"[::]:7300"}
^C{"level":"info","ts":"2024-12-23T20:32:07.143Z","subsystem":"server","msg":"starting shutdown"}
{"level":"info","ts":"2024-12-23T20:32:07.143Z","subsystem":"server","msg":"shutdown upstream server"}
{"level":"info","ts":"2024-12-23T20:32:07.143Z","subsystem":"server","msg":"shutdown proxy server"}
{"level":"info","ts":"2024-12-23T20:32:07.143Z","subsystem":"server","msg":"left cluster"}
{"level":"info","ts":"2024-12-23T20:32:07.143Z","subsystem":"server","msg":"shutdown admin server"}
{"level":"info","ts":"2024-12-23T20:32:07.289Z","subsystem":"server","msg":"shutdown complete"}
```

piko-server.yaml
```yaml
proxy:
  bind_addr: ":7200"
  access_log: true

upstream:
  bind_addr: ":7300"
  auth:
    disable_disconnect_on_expiry: true

admin:
  bind_addr: ":7400"

cluster:
  node_id_prefix: "sombra-proxy"
  gossip:
    bind_addr: ":7500"

log:
  level: info
```