### PR TITLE
server: adding upstream connection rebalancing

### DIFF
--- a/cli/server/status/cluster.go
+++ b/cli/server/status/cluster.go
@@ -129,11 +129,9 @@ func showClusterNode(nodeID string, c *client.Client) {
 		os.Exit(1)
 	}
 
-	// Print node details including upstreams (total connections)
 	fmt.Printf("Node ID: %s\n", node.ID)
 	fmt.Printf("Total Connections: %d\n", node)
 
-	// Print the rest of the node data
 	b, _ := yaml.Marshal(node)
 	fmt.Print(string(b))
 }

--- a/server/cluster/node_test.go
+++ b/server/cluster/node_test.go
@@ -1,0 +1,62 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+
+	"github.com/andydunstall/piko/bench/config"
+)
+
+func TestMaybeShedConnections(t *testing.T) {
+	node := &Node{
+		ID:        "test-node",
+		Endpoints: map[string]int{"ep1": 50, "ep2": 30},
+	}
+
+	metadata := []*NodeMetadata{
+		{ID: "node1", Upstreams: 80},
+		{ID: "node2", Upstreams: 40},
+	}
+
+	average := float64(60)
+	totalConnections := 120
+	threshold := 0.1 // 10% above average
+	shedRate := 0.05 // Shed 5% per iteration
+
+	node.maybeShedConnections(metadata, average, threshold, shedRate, totalConnections)
+
+	// Verify connection counts after shedding.
+	totalAfter := 0
+	for _, count := range node.Endpoints {
+		totalAfter += count
+	}
+	if totalAfter >= 80 {
+		t.Errorf("node did not shed enough connections, remaining: %d", totalAfter)
+	}
+}
+
+func TestStartRebalancing(t *testing.T) {
+	nodes := []*Node{
+		{ID: "node1", Endpoints: map[string]int{"endpoint1": 10}},
+		{ID: "node2", Endpoints: map[string]int{"endpoint2": 20}},
+		{ID: "node3", Endpoints: map[string]int{"endpoint3": 90}},
+	}
+
+	// Mocked configuration.
+	cfg := config.Config{
+		RebalanceThreshold: 0.1,  // 10% above average
+		ShedRate:           0.05, // 5% per second
+	}
+
+	// Node instance for testing.
+	testNode := nodes[0]
+
+	go testNode.StartRebalancing(nodes, time.Millisecond*500, cfg)
+
+	time.Sleep(time.Second * 2)
+
+	// Verify connection counts were rebalanced.
+	if nodes[0].Endpoints["endpoint1"] > 10 {
+		t.Errorf("node1 should have shed connections, got %d", nodes[0].Endpoints["ep1"])
+	}
+}


### PR DESCRIPTION
Heey @andydunstall, 

here I have tried to solve upstream connection rebalancing, 

first by updating config https://github.com/andydunstall/piko/pull/210/commits/79dbe0f34d473aa47b03edf76e58f0b22f236375
then I have added updated total and average cluster metrics, https://github.com/andydunstall/piko/pull/210/commits/565e4a93c016bc375c567572e1792cbac57323d1
shedding connections is implemented here, 
https://github.com/andydunstall/piko/pull/210/commits/832a679b442ce5c9db0e7a7ec8e4ba9f6aba92f7
rebalancing is implemented here
https://github.com/andydunstall/piko/pull/210/commits/2d0f12b17cffe956b34fac73a12cdf992c9f8c9d 

also here are little initial tests 
https://github.com/andydunstall/piko/pull/210/commits/7583042a96282c198705b58c5bcfcd9f27f485cd 

This is just a draft pr, feel free to let me know does this works for you, what can be improved, changed and added so we have good implementation of solution