### PR TITLE
agent: fix panic when defining several http endpoints

### DIFF
--- a/agent/reverseproxy/server_test.go
+++ b/agent/reverseproxy/server_test.go
@@ -1,0 +1,94 @@
+package reverseproxy
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/andydunstall/piko/agent/config"
+	"github.com/andydunstall/piko/pkg/log"
+	"github.com/andydunstall/piko/pkg/middleware"
+)
+
+func mustGet(t *testing.T, url string) string {
+	resp, err := http.Get(url)
+	if err != nil {
+		panic(err)
+	}
+	if resp.Body != nil {
+		defer func() {
+			// nolint
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}()
+	}
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	return string(body)
+}
+
+func TestServer_Forward(t *testing.T) {
+	// Issue https://github.com/andydunstall/piko/issues/216
+	t.Run("multiendpoint", func(t *testing.T) {
+
+		upstream := httptest.NewServer(http.HandlerFunc(
+			func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				// nolint
+				w.Write([]byte("bar"))
+			},
+		))
+		defer upstream.Close()
+
+		registry := prometheus.NewRegistry()
+		metrics := middleware.NewLabeledMetrics("test")
+		configs := []config.ListenerConfig{
+			{
+				EndpointID: "my-endpoint",
+				Addr:       upstream.URL,
+			},
+			{
+				EndpointID: "my-endpoint-2",
+				Addr:       upstream.URL,
+			},
+		}
+		metrics.Register(registry)
+
+		testConfig := func(t *testing.T, cfg config.ListenerConfig) {
+			// Need a real listener to test Server
+			ln, err := net.Listen("tcp", ":0")
+			if err != nil {
+				panic(err)
+			}
+			defer ln.Close()
+			lnPort := ln.Addr().(*net.TCPAddr).Port
+
+			server := NewServer(cfg, metrics, log.NewNopLogger())
+			go func() {
+				if err := server.Serve(ln); !errors.Is(err, net.ErrClosed) {
+					panic(err)
+				}
+			}()
+
+			body := mustGet(t, fmt.Sprintf("http://localhost:%d/foo/bar?a=b", lnPort))
+			assert.Equal(t, "bar", body)
+		}
+
+		t.Run("fist", func(t *testing.T) {
+			testConfig(t, configs[0])
+		})
+		t.Run("second", func(t *testing.T) {
+			testConfig(t, configs[1])
+		})
+	})
+}

--- a/pkg/middleware/metrics.go
+++ b/pkg/middleware/metrics.go
@@ -9,6 +9,61 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+type gaugeOptions struct {
+	RequestsInFlight prometheus.GaugeOpts
+	RequestsTotal    prometheus.CounterOpts
+	RequestLatency   prometheus.HistogramOpts
+	RequestSize      prometheus.HistogramOpts
+	ResponseSize     prometheus.HistogramOpts
+}
+
+func newOptions(subsystem string) gaugeOptions {
+	sizeBuckets := prometheus.ExponentialBuckets(256, 4, 8)
+	return gaugeOptions{
+		RequestsInFlight: prometheus.GaugeOpts{
+			Namespace: "piko",
+			Subsystem: subsystem,
+			Name:      "requests_in_flight",
+			Help:      "Number of requests currently handled by this server.",
+		},
+		RequestsTotal: prometheus.CounterOpts{
+			Namespace: "piko",
+			Subsystem: subsystem,
+			Name:      "requests_total",
+			Help:      "Total requests.",
+		},
+		RequestLatency: prometheus.HistogramOpts{
+			Namespace: "piko",
+			Subsystem: subsystem,
+			Name:      "request_latency_seconds",
+			Help:      "Request latency.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		RequestSize: prometheus.HistogramOpts{
+			Namespace: "piko",
+			Subsystem: subsystem,
+			Name:      "request_size_bytes",
+			Help:      "Request size",
+			Buckets:   sizeBuckets,
+		},
+		ResponseSize: prometheus.HistogramOpts{
+			Namespace: "piko",
+			Subsystem: subsystem,
+			Name:      "response_size_bytes",
+			Help:      "Response size",
+			Buckets:   sizeBuckets,
+		},
+	}
+}
+
+type LabeledMetrics struct {
+	RequestsInFlight *prometheus.GaugeVec
+	RequestsTotal    *prometheus.CounterVec
+	RequestLatency   *prometheus.HistogramVec
+	RequestSize      *prometheus.HistogramVec
+	ResponseSize     *prometheus.HistogramVec
+}
+
 type Metrics struct {
 	RequestsInFlight prometheus.Gauge
 	RequestsTotal    *prometheus.CounterVec
@@ -17,81 +72,53 @@ type Metrics struct {
 	ResponseSize     prometheus.Histogram
 }
 
-func NewMetrics(subsystem string) *Metrics {
-	sizeBuckets := prometheus.ExponentialBuckets(256, 4, 8)
-	return &Metrics{
-		RequestsInFlight: prometheus.NewGauge(
-			prometheus.GaugeOpts{
-				Namespace: "piko",
-				Subsystem: subsystem,
-				Name:      "requests_in_flight",
-				Help:      "Number of requests currently handled by this server.",
-			},
+func NewLabeledMetrics(subsystem string) *LabeledMetrics {
+	opts := newOptions(subsystem)
+	return &LabeledMetrics{
+		RequestsInFlight: prometheus.NewGaugeVec(
+			opts.RequestsInFlight,
+			[]string{"endpoint"},
 		),
 		RequestsTotal: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: "piko",
-				Subsystem: subsystem,
-				Name:      "requests_total",
-				Help:      "Total requests.",
-			},
+			opts.RequestsTotal,
+			[]string{"endpoint", "status", "method"},
+		),
+		RequestLatency: prometheus.NewHistogramVec(
+			opts.RequestLatency,
+			[]string{"endpoint", "status", "method"},
+		),
+		RequestSize:  prometheus.NewHistogramVec(opts.RequestSize, []string{"endpoint"}),
+		ResponseSize: prometheus.NewHistogramVec(opts.ResponseSize, []string{"endpoint"}),
+	}
+}
+
+func (lm *LabeledMetrics) Register(registry prometheus.Registerer) {
+	registry.MustRegister(
+		lm.RequestsInFlight,
+		lm.RequestsTotal,
+		lm.RequestLatency,
+		lm.RequestSize,
+		lm.ResponseSize,
+	)
+}
+
+func NewMetrics(subsystem string) *Metrics {
+	opts := newOptions(subsystem)
+	return &Metrics{
+		RequestsInFlight: prometheus.NewGauge(opts.RequestsInFlight),
+		RequestsTotal: prometheus.NewCounterVec(opts.RequestsTotal,
 			[]string{"status", "method"},
 		),
 		RequestLatency: prometheus.NewHistogramVec(
-			prometheus.HistogramOpts{
-				Namespace: "piko",
-				Subsystem: subsystem,
-				Name:      "request_latency_seconds",
-				Help:      "Request latency.",
-				Buckets:   prometheus.DefBuckets,
-			},
+			opts.RequestLatency,
 			[]string{"status", "method"},
 		),
-		RequestSize: prometheus.NewHistogram(
-			prometheus.HistogramOpts{
-				Namespace: "piko",
-				Subsystem: subsystem,
-				Name:      "request_size_bytes",
-				Help:      "Request size",
-				Buckets:   sizeBuckets,
-			},
-		),
-		ResponseSize: prometheus.NewHistogram(
-			prometheus.HistogramOpts{
-				Namespace: "piko",
-				Subsystem: subsystem,
-				Name:      "response_size_bytes",
-				Help:      "Response size",
-				Buckets:   sizeBuckets,
-			},
-		),
+		RequestSize:  prometheus.NewHistogram(opts.RequestSize),
+		ResponseSize: prometheus.NewHistogram(opts.ResponseSize),
 	}
 }
 
-func (m *Metrics) Handler() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		m.RequestsInFlight.Inc()
-		defer m.RequestsInFlight.Dec()
-
-		start := time.Now()
-
-		// Process request.
-		c.Next()
-
-		m.RequestsTotal.With(prometheus.Labels{
-			"status": strconv.Itoa(c.Writer.Status()),
-			"method": c.Request.Method,
-		}).Inc()
-		m.RequestLatency.With(prometheus.Labels{
-			"status": strconv.Itoa(c.Writer.Status()),
-			"method": c.Request.Method,
-		}).Observe(float64(time.Since(start).Milliseconds()) / 1000)
-		m.RequestSize.Observe(float64(computeApproximateRequestSize(c.Request)))
-		m.ResponseSize.Observe(float64(c.Writer.Size()))
-	}
-}
-
-func (m *Metrics) Register(registry *prometheus.Registry) {
+func (m *Metrics) Register(registry prometheus.Registerer) {
 	registry.MustRegister(
 		m.RequestsInFlight,
 		m.RequestsTotal,
@@ -99,6 +126,60 @@ func (m *Metrics) Register(registry *prometheus.Registry) {
 		m.RequestSize,
 		m.ResponseSize,
 	)
+}
+
+type observer struct {
+	RequestsInFlight prometheus.Gauge
+	RequestsTotal    *prometheus.CounterVec
+	RequestLatency   prometheus.ObserverVec
+	RequestSize      prometheus.Observer
+	ResponseSize     prometheus.Observer
+}
+
+func (lm *LabeledMetrics) Handler(endpointID string) gin.HandlerFunc {
+	obs := observer{
+		RequestsInFlight: lm.RequestsInFlight.WithLabelValues(endpointID),
+		RequestsTotal:    lm.RequestsTotal.MustCurryWith(prometheus.Labels{"endpoint": endpointID}),
+		RequestLatency:   lm.RequestLatency.MustCurryWith(prometheus.Labels{"endpoint": endpointID}),
+		RequestSize:      lm.RequestSize.WithLabelValues(endpointID),
+		ResponseSize:     lm.ResponseSize.WithLabelValues(endpointID),
+	}
+	return obs.Handler()
+}
+
+func (m *Metrics) Handler() gin.HandlerFunc {
+	obs := observer{
+		RequestsInFlight: m.RequestsInFlight,
+		RequestsTotal:    m.RequestsTotal,
+		RequestLatency:   m.RequestLatency,
+		RequestSize:      m.RequestSize,
+		ResponseSize:     m.ResponseSize,
+	}
+	return obs.Handler()
+}
+
+func (o observer) Handler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		o.RequestsInFlight.Inc()
+		defer o.RequestsInFlight.Dec()
+
+		start := time.Now()
+
+		// Process request.
+		c.Next()
+
+		o.RequestsTotal.With(prometheus.Labels{
+			"status": strconv.Itoa(c.Writer.Status()),
+			"method": c.Request.Method,
+		}).Inc()
+		o.RequestLatency.With(prometheus.Labels{
+			"status": strconv.Itoa(c.Writer.Status()),
+			"method": c.Request.Method,
+		}).Observe(float64(time.Since(start).Milliseconds()) / 1000)
+
+		o.RequestSize.Observe(float64(computeApproximateRequestSize(c.Request)))
+		o.ResponseSize.Observe(float64(c.Writer.Size()))
+	}
 }
 
 func computeApproximateRequestSize(r *http.Request) int {

--- a/server/proxy/server.go
+++ b/server/proxy/server.go
@@ -68,11 +68,11 @@ func NewServer(
 
 	router.Use(middleware.NewLogger(proxyConfig.AccessLog, logger))
 
-	metrics := middleware.NewMetrics("proxy")
 	if registry != nil {
+		metrics := middleware.NewMetrics("proxy")
 		metrics.Register(registry)
+		router.Use(metrics.Handler())
 	}
-	router.Use(metrics.Handler())
 
 	s.registerRoutes(router)
 


### PR DESCRIPTION
This PR adds a new `middleware.LabeledMetrics` type that mirrors the existing `middleware.Metrics` type, but adds an "endpoint" label to all metrics.

`reverseproxy.Server` type is updated to use the new `LabeledMetrics` type, fixing issue #216 