### PR TITLE
workflow: add package write permission to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ env:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   # # # # # # # # # # # # # # # # #


### PR DESCRIPTION
Adds `package: write` permission to the release workflow to fix publishing packages to GHCR.