### PR TITLE
Allow for Proxy Server and Agent Access Log Config to be fine-grained.

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -33,7 +33,7 @@ type ListenerConfig struct {
 	// Defaults to "http".
 	Protocol ListenerProtocol `json:"protocol" yaml:"protocol"`
 
-	// AccessLogConfig allows us to control how the incoming requests to
+	// AccessLog allows us to control how the incoming requests to
 	// the proxy are logged.
 	AccessLog log.AccessLogConfig `json:"access_log" yaml:"access_log"`
 
@@ -126,7 +126,7 @@ func (c *ListenerConfig) Validate() error {
 	}
 
 	if err := c.AccessLog.Validate(); err != nil {
-		return fmt.Errorf("access_log: %w", err)
+		return fmt.Errorf("access log: %w", err)
 	}
 
 	return nil

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -33,9 +33,9 @@ type ListenerConfig struct {
 	// Defaults to "http".
 	Protocol ListenerProtocol `json:"protocol" yaml:"protocol"`
 
-	// AccessLog indicates whether to log all incoming connections and requests
-	// for the endpoint.
-	AccessLog bool `json:"access_log" yaml:"access_log"`
+	// AccessLogConfig allows us to control how the incoming requests to
+	// the proxy are logged.
+	AccessLog log.AccessLogConfig `json:"access_log" yaml:"access_log"`
 
 	// Timeout is the timeout to forward incoming requests to the upstream.
 	Timeout time.Duration `json:"timeout" yaml:"timeout"`
@@ -124,6 +124,11 @@ func (c *ListenerConfig) Validate() error {
 	if err := c.TLS.Validate(); err != nil {
 		return fmt.Errorf("tls: %w", err)
 	}
+
+	if err := c.AccessLog.Validate(); err != nil {
+		return fmt.Errorf("access_log: %w", err)
+	}
+
 	return nil
 }
 

--- a/agent/tcpproxy/server.go
+++ b/agent/tcpproxy/server.go
@@ -114,18 +114,18 @@ func (s *Server) removeConn(c net.Conn) {
 }
 
 func (s *Server) logConnOpened() {
-	if s.conf.AccessLog.Enabled {
-		s.accessLogger.Info("connection opened")
-	} else {
+	if s.conf.AccessLog.Disable {
 		s.accessLogger.Debug("connection opened")
+	} else {
+		s.accessLogger.Info("connection opened")
 	}
 }
 
 func (s *Server) logConnClosed() {
-	if s.conf.AccessLog.Enabled {
-		s.accessLogger.Info("connection closed")
-	} else {
+	if s.conf.AccessLog.Disable {
 		s.accessLogger.Debug("connection closed")
+	} else {
+		s.accessLogger.Info("connection closed")
 	}
 }
 

--- a/agent/tcpproxy/server.go
+++ b/agent/tcpproxy/server.go
@@ -114,7 +114,7 @@ func (s *Server) removeConn(c net.Conn) {
 }
 
 func (s *Server) logConnOpened() {
-	if s.conf.AccessLog {
+	if s.conf.AccessLog.Enabled {
 		s.accessLogger.Info("connection opened")
 	} else {
 		s.accessLogger.Debug("connection opened")
@@ -122,7 +122,7 @@ func (s *Server) logConnOpened() {
 }
 
 func (s *Server) logConnClosed() {
-	if s.conf.AccessLog {
+	if s.conf.AccessLog.Enabled {
 		s.accessLogger.Info("connection closed")
 	} else {
 		s.accessLogger.Debug("connection closed")

--- a/cli/agent/http.go
+++ b/cli/agent/http.go
@@ -41,7 +41,7 @@ Examples:
 		"access-log",
 		true,
 		`
-Whether to log all incoming HTTP requests and responses as 'info' logs.`,
+Whether to log all incoming HTTP requests and responses as 'info' logs. For more options, use a configuration file.`,
 	)
 
 	var timeout time.Duration
@@ -62,8 +62,10 @@ Timeout forwarding incoming HTTP requests to the upstream.`,
 			EndpointID: args[0],
 			Addr:       args[1],
 			Protocol:   config.ListenerProtocolHTTP,
-			AccessLog:  accessLog,
-			Timeout:    timeout,
+			AccessLog: log.AccessLogConfig{
+				Enabled: accessLog,
+			},
+			Timeout: timeout,
 		}}
 
 		var err error

--- a/cli/agent/http.go
+++ b/cli/agent/http.go
@@ -35,17 +35,14 @@ Examples:
 `,
 	}
 
-	var accessLog bool
-	cmd.Flags().BoolVar(
-		&accessLog,
-		"access-log",
-		true,
-		`
-Whether to log all incoming HTTP requests and responses as 'info' logs. For more options, use a configuration file.`,
-	)
+	accessLog := log.AccessLogConfig{
+		Disable: false,
+	}
+	flags := cmd.Flags()
+	accessLog.RegisterFlags(flags, "")
 
 	var timeout time.Duration
-	cmd.Flags().DurationVar(
+	flags.DurationVar(
 		&timeout,
 		"timeout",
 		time.Second*10,
@@ -62,10 +59,8 @@ Timeout forwarding incoming HTTP requests to the upstream.`,
 			EndpointID: args[0],
 			Addr:       args[1],
 			Protocol:   config.ListenerProtocolHTTP,
-			AccessLog: log.AccessLogConfig{
-				Enabled: accessLog,
-			},
-			Timeout: timeout,
+			AccessLog:  accessLog,
+			Timeout:    timeout,
 		}}
 
 		var err error

--- a/cli/agent/tcp.go
+++ b/cli/agent/tcp.go
@@ -32,13 +32,13 @@ Examples:
 `,
 	}
 
-	var accessLog bool
+	var disableAccessLogging bool
 	cmd.Flags().BoolVar(
-		&accessLog,
-		"access-log",
-		true,
+		&disableAccessLogging,
+		"access-log.disable",
+		false,
 		`
-Whether to log all incoming connections as 'info' logs. For more options, use a configuration file.`,
+Disables logging all incoming connections as 'info' logs. For more options, use a configuration file.`,
 	)
 
 	var timeout time.Duration
@@ -60,7 +60,7 @@ Timeout connecting to the upstream.`,
 			Addr:       args[1],
 			Protocol:   config.ListenerProtocolTCP,
 			AccessLog: log.AccessLogConfig{
-				Enabled: accessLog,
+				Disable: disableAccessLogging,
 			},
 			Timeout: timeout,
 		}}

--- a/cli/agent/tcp.go
+++ b/cli/agent/tcp.go
@@ -38,7 +38,7 @@ Examples:
 		"access-log",
 		true,
 		`
-Whether to log all incoming connections as 'info' logs.`,
+Whether to log all incoming connections as 'info' logs. For more options, use a configuration file.`,
 	)
 
 	var timeout time.Duration
@@ -59,8 +59,10 @@ Timeout connecting to the upstream.`,
 			EndpointID: args[0],
 			Addr:       args[1],
 			Protocol:   config.ListenerProtocolTCP,
-			AccessLog:  accessLog,
-			Timeout:    timeout,
+			AccessLog: log.AccessLogConfig{
+				Enabled: accessLog,
+			},
+			Timeout: timeout,
 		}}
 
 		var err error

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -126,20 +126,18 @@ type AccessLogConfig struct {
 	// while still respecting the header allow and block lists.
 	Enabled bool `json:"enabled" yaml:"enabled"`
 
-	// Control how Request Headers are logged.
 	RequestHeaders AccessLogHeaderConfig `json:"request_headers" yaml:"request_headers"`
 
-	// Control how Response Headers are logged.
 	ResponseHeaders AccessLogHeaderConfig `json:"response_headers" yaml:"response_headers"`
 }
 
 func (c *AccessLogConfig) Validate() error {
 	if err := c.RequestHeaders.Validate(); err != nil {
-		return fmt.Errorf("request_headers: %w", err)
+		return fmt.Errorf("request headers: %w", err)
 	}
 
 	if err := c.ResponseHeaders.Validate(); err != nil {
-		return fmt.Errorf("response_headers: %w", err)
+		return fmt.Errorf("response headers: %w", err)
 	}
 	return nil
 }

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -121,10 +121,9 @@ Block these headers from being logged`,
 }
 
 type AccessLogConfig struct {
-	// If Access logging is enabled, using the 'info' log level.
 	// If disabled, logs will be emitted with the 'debug' log level,
-	// while still respecting the header allow and block lists.
-	Enabled bool `json:"enabled" yaml:"enabled"`
+	// while respecting the header allow and block lists.
+	Disable bool `json:"disable" yaml:"disable"`
 
 	RequestHeaders AccessLogHeaderConfig `json:"request_headers" yaml:"request_headers"`
 
@@ -145,11 +144,11 @@ func (c *AccessLogConfig) Validate() error {
 func (c *AccessLogConfig) RegisterFlags(fs *pflag.FlagSet, prefix string) {
 	prefix = prefix + ".access-log."
 	fs.BoolVar(
-		&c.Enabled,
-		prefix+"enabled",
+		&c.Disable,
+		prefix+"disable",
 		true,
 		`
-If Access logging is enabled`,
+If Access logging is disabled`,
 	)
 	c.RequestHeaders.RegisterFlags(fs, prefix+"request-headers.")
 	c.ResponseHeaders.RegisterFlags(fs, prefix+"response-headers.")

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -142,11 +142,15 @@ func (c *AccessLogConfig) Validate() error {
 }
 
 func (c *AccessLogConfig) RegisterFlags(fs *pflag.FlagSet, prefix string) {
-	prefix = prefix + ".access-log."
+	if len(prefix) > 0 {
+		prefix = prefix + ".access-log."
+	} else {
+		prefix = "access-log."
+	}
 	fs.BoolVar(
 		&c.Disable,
 		prefix+"disable",
-		true,
+		false,
 		`
 If Access logging is disabled`,
 	)

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -50,10 +50,10 @@ func NewLogger(accessLogConfig log.AccessLogConfig, logger log.Logger) gin.Handl
 		}
 		if c.Writer.Status() >= http.StatusInternalServerError {
 			logger.Warn("request", zap.Any("request", req))
-		} else if accessLogConfig.Enabled {
-			logger.Info("request", zap.Any("request", req))
-		} else {
+		} else if accessLogConfig.Disable {
 			logger.Debug("request", zap.Any("request", req))
+		} else {
+			logger.Info("request", zap.Any("request", req))
 		}
 	}
 }

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"net/textproto"
 	"strings"
 	"time"
 
@@ -22,9 +23,21 @@ type loggedRequest struct {
 	Duration        string      `json:"duration"`
 }
 
+type logHeaderFilter struct {
+	allowList map[string]string
+	blockList map[string]string
+}
+
+type loggerConfig struct {
+	RequestHeader  logHeaderFilter
+	ResponseHeader logHeaderFilter
+}
+
 // NewLogger creates logging middleware that logs every request.
-func NewLogger(accessLogConfig log.AccessLogConfig, logger log.Logger) gin.HandlerFunc {
-	logger = logger.WithSubsystem(logger.Subsystem() + ".access")
+func NewLogger(config log.AccessLogConfig, l log.Logger) gin.HandlerFunc {
+	l = l.WithSubsystem(l.Subsystem() + ".access")
+
+	lc := NewLoggerConfig(config)
 	return func(c *gin.Context) {
 		s := time.Now()
 
@@ -35,8 +48,8 @@ func NewLogger(accessLogConfig log.AccessLogConfig, logger log.Logger) gin.Handl
 			return
 		}
 
-		requestHeaders := accessLogConfig.RequestHeaders.Filter(c.Request.Header)
-		responseHeaders := accessLogConfig.ResponseHeaders.Filter(c.Writer.Header())
+		requestHeaders := lc.RequestHeader.Filter(c.Request.Header)
+		responseHeaders := lc.ResponseHeader.Filter(c.Writer.Header())
 
 		req := &loggedRequest{
 			Proto:           c.Request.Proto,
@@ -49,11 +62,57 @@ func NewLogger(accessLogConfig log.AccessLogConfig, logger log.Logger) gin.Handl
 			Duration:        time.Since(s).String(),
 		}
 		if c.Writer.Status() >= http.StatusInternalServerError {
-			logger.Warn("request", zap.Any("request", req))
-		} else if accessLogConfig.Disable {
-			logger.Debug("request", zap.Any("request", req))
+			l.Warn("request", zap.Any("request", req))
+		} else if config.Disable {
+			l.Debug("request", zap.Any("request", req))
 		} else {
-			logger.Info("request", zap.Any("request", req))
+			l.Info("request", zap.Any("request", req))
 		}
 	}
+}
+
+func (l *logHeaderFilter) New(allowList []string, blockList []string) {
+	if len(allowList) > 0 {
+		l.allowList = make(map[string]string)
+		for _, el := range allowList {
+			h := textproto.CanonicalMIMEHeaderKey(el)
+			l.allowList[h] = h
+		}
+	}
+
+	if len(blockList) > 0 {
+		l.blockList = make(map[string]string)
+		for _, el := range blockList {
+			h := textproto.CanonicalMIMEHeaderKey(el)
+			l.blockList[h] = h
+		}
+	}
+}
+
+func (l *logHeaderFilter) Filter(h http.Header) http.Header {
+	if len(l.allowList) > 0 {
+		for name := range h {
+			// Use the map created during validation to hasten lookups.
+			if _, ok := l.allowList[name]; !ok {
+				h.Del(name)
+			}
+		}
+		return h
+	}
+
+	if len(l.blockList) > 0 {
+		for _, blocked := range l.blockList {
+			h.Del(blocked)
+		}
+		return h
+	}
+
+	return h
+}
+
+func NewLoggerConfig(c log.AccessLogConfig) loggerConfig {
+	l := loggerConfig{}
+	l.RequestHeader.New(c.RequestHeaders.Allowlist, c.RequestHeaders.Blocklist)
+	l.ResponseHeader.New(c.ResponseHeaders.Allowlist, c.ResponseHeaders.Blocklist)
+	return l
 }

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -37,7 +37,7 @@ type loggerConfig struct {
 func NewLogger(config log.AccessLogConfig, l log.Logger) gin.HandlerFunc {
 	l = l.WithSubsystem(l.Subsystem() + ".access")
 
-	lc := NewLoggerConfig(config)
+	lc := newLoggerConfig(config)
 	return func(c *gin.Context) {
 		s := time.Now()
 
@@ -110,7 +110,7 @@ func (l *logHeaderFilter) Filter(h http.Header) http.Header {
 	return h
 }
 
-func NewLoggerConfig(c log.AccessLogConfig) loggerConfig {
+func newLoggerConfig(c log.AccessLogConfig) loggerConfig {
 	l := loggerConfig{}
 	l.RequestHeader.New(c.RequestHeaders.Allowlist, c.RequestHeaders.Blocklist)
 	l.ResponseHeader.New(c.ResponseHeaders.Allowlist, c.ResponseHeaders.Blocklist)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -187,7 +187,7 @@ type ProxyConfig struct {
 	// Timeout is the timeout to forward incoming requests to the upstream.
 	Timeout time.Duration `json:"timeout" yaml:"timeout"`
 
-	// AccessLogConfig allows us to control how the incoming requests to
+	// AccessLog allows us to control how the incoming requests to
 	// the proxy are logged.
 	AccessLog log.AccessLogConfig `json:"access_log" yaml:"access_log"`
 
@@ -207,7 +207,7 @@ func (c *ProxyConfig) Validate() error {
 	}
 
 	if err := c.AccessLog.Validate(); err != nil {
-		return fmt.Errorf("access_log: %w", err)
+		return fmt.Errorf("access log: %w", err)
 	}
 	return nil
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -187,9 +187,9 @@ type ProxyConfig struct {
 	// Timeout is the timeout to forward incoming requests to the upstream.
 	Timeout time.Duration `json:"timeout" yaml:"timeout"`
 
-	// AccessLog indicates whether to log all incoming connections and
-	// requests.
-	AccessLog bool `json:"access_log" yaml:"access_log"`
+	// AccessLogConfig allows us to control how the incoming requests to
+	// the proxy are logged.
+	AccessLog log.AccessLogConfig `json:"access_log" yaml:"access_log"`
 
 	Auth auth.Config `json:"auth" yaml:"auth"`
 
@@ -204,6 +204,10 @@ func (c *ProxyConfig) Validate() error {
 	}
 	if err := c.TLS.Validate(); err != nil {
 		return fmt.Errorf("tls: %w", err)
+	}
+
+	if err := c.AccessLog.Validate(); err != nil {
+		return fmt.Errorf("access_log: %w", err)
 	}
 	return nil
 }
@@ -245,13 +249,7 @@ advertise address of '10.26.104.14:8000'.`,
 Timeout when forwarding incoming requests to the upstream.`,
 	)
 
-	fs.BoolVar(
-		&c.AccessLog,
-		"proxy.access-log",
-		c.AccessLog,
-		`
-Whether to log all incoming connections and requests.`,
-	)
+	c.AccessLog.RegisterFlags(fs, "proxy")
 
 	c.HTTP.RegisterFlags(fs, "proxy")
 
@@ -519,9 +517,11 @@ type Config struct {
 func Default() *Config {
 	return &Config{
 		Proxy: ProxyConfig{
-			BindAddr:  ":8000",
-			Timeout:   time.Second * 30,
-			AccessLog: true,
+			BindAddr: ":8000",
+			Timeout:  time.Second * 30,
+			AccessLog: log.AccessLogConfig{
+				Enabled: true,
+			},
 			HTTP: HTTPConfig{
 				ReadTimeout:       time.Second * 10,
 				ReadHeaderTimeout: time.Second * 10,

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -520,7 +520,7 @@ func Default() *Config {
 			BindAddr: ":8000",
 			Timeout:  time.Second * 30,
 			AccessLog: log.AccessLogConfig{
-				Enabled: true,
+				Disable: false,
 			},
 			HTTP: HTTPConfig{
 				ReadTimeout:       time.Second * 10,

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -28,7 +28,16 @@ proxy:
   bind_addr: 10.15.104.25:8000
   advertise_addr: 1.2.3.4:8000
   timeout: 20s
-  access_log: true
+  access_log:
+    enabled: false
+    request_headers:
+      blocklist:
+        - abc
+        - xyz
+    response_headers:
+      allowlist:
+        - def
+        - ghi
 
   http:
     read_timeout: 5s
@@ -125,7 +134,15 @@ grace_period: 2m
 			BindAddr:      "10.15.104.25:8000",
 			AdvertiseAddr: "1.2.3.4:8000",
 			Timeout:       time.Second * 20,
-			AccessLog:     true,
+			AccessLog: log.AccessLogConfig{
+				Enabled: false,
+				RequestHeaders: log.AccessLogHeaderConfig{
+					Blocklist: []string{"abc", "xyz"},
+				},
+				ResponseHeaders: log.AccessLogHeaderConfig{
+					Allowlist: []string{"def", "ghi"},
+				},
+			},
 			HTTP: HTTPConfig{
 				ReadTimeout:       time.Second * 5,
 				ReadHeaderTimeout: time.Second * 5,
@@ -217,7 +234,9 @@ func TestConfig_LoadFlags(t *testing.T) {
 		"--proxy.bind-addr", "10.15.104.25:8000",
 		"--proxy.advertise-addr", "1.2.3.4:8000",
 		"--proxy.timeout", "20s",
-		"--proxy.access-log",
+		"--proxy.access-log.enabled",
+		"--proxy.access-log.request-headers.allowlist", "abc,def",
+		"--proxy.access-log.response-headers.blocklist", "xyz,ghi",
 		"--proxy.http.read-timeout", "5s",
 		"--proxy.http.read-header-timeout", "5s",
 		"--proxy.http.write-timeout", "5s",
@@ -277,7 +296,15 @@ func TestConfig_LoadFlags(t *testing.T) {
 			BindAddr:      "10.15.104.25:8000",
 			AdvertiseAddr: "1.2.3.4:8000",
 			Timeout:       time.Second * 20,
-			AccessLog:     true,
+			AccessLog: log.AccessLogConfig{
+				Enabled: true,
+				RequestHeaders: log.AccessLogHeaderConfig{
+					Allowlist: []string{"abc", "def"},
+				},
+				ResponseHeaders: log.AccessLogHeaderConfig{
+					Blocklist: []string{"xyz", "ghi"},
+				},
+			},
 			HTTP: HTTPConfig{
 				ReadTimeout:       time.Second * 5,
 				ReadHeaderTimeout: time.Second * 5,

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -29,7 +29,7 @@ proxy:
   advertise_addr: 1.2.3.4:8000
   timeout: 20s
   access_log:
-    enabled: false
+    disable: true
     request_headers:
       blocklist:
         - abc
@@ -135,7 +135,7 @@ grace_period: 2m
 			AdvertiseAddr: "1.2.3.4:8000",
 			Timeout:       time.Second * 20,
 			AccessLog: log.AccessLogConfig{
-				Enabled: false,
+				Disable: true,
 				RequestHeaders: log.AccessLogHeaderConfig{
 					Blocklist: []string{"abc", "xyz"},
 				},
@@ -234,7 +234,7 @@ func TestConfig_LoadFlags(t *testing.T) {
 		"--proxy.bind-addr", "10.15.104.25:8000",
 		"--proxy.advertise-addr", "1.2.3.4:8000",
 		"--proxy.timeout", "20s",
-		"--proxy.access-log.enabled",
+		"--proxy.access-log.disable",
 		"--proxy.access-log.request-headers.allowlist", "abc,def",
 		"--proxy.access-log.response-headers.blocklist", "xyz,ghi",
 		"--proxy.http.read-timeout", "5s",
@@ -297,7 +297,7 @@ func TestConfig_LoadFlags(t *testing.T) {
 			AdvertiseAddr: "1.2.3.4:8000",
 			Timeout:       time.Second * 20,
 			AccessLog: log.AccessLogConfig{
-				Enabled: true,
+				Disable: true,
 				RequestHeaders: log.AccessLogHeaderConfig{
 					Allowlist: []string{"abc", "def"},
 				},


### PR DESCRIPTION
Solves https://github.com/andydunstall/piko/issues/227

I chose to only solve for the request and response header logging in this PR, as a way of proving out the concept before adding more configuration options.

## Changes
 
- Allows for both the Agent and Proxy Server config files to specify request and response headers to allow or block
    - Note only one of the properties can be specified in a configuration
- Allows for the Proxy Server, and Agent CLIs command to perform the same functionality

## Breaking Changes
- The `proxy.access_log` property for the Proxy Server has been changed from a simple boolean to a more complex object, but we still retain the default option of logging all request properties, including all request and response headers