### PR TITLE
agent: add connect.proxy-url flag

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -246,6 +246,10 @@ type ConnectConfig struct {
 	Timeout time.Duration `json:"timeout" yaml:"timeout"`
 
 	TLS TLSConfig `json:"tls" yaml:"tls"`
+
+	// ProxyURL is the proxy URL to proxy the request from the agent to the
+	// Piko server (optional).
+	ProxyURL string `json:"proxy_url" yaml:"proxy_url"`
 }
 
 func (c *ConnectConfig) Validate() error {
@@ -254,6 +258,11 @@ func (c *ConnectConfig) Validate() error {
 	}
 	if _, err := url.Parse(c.URL); err != nil {
 		return fmt.Errorf("invalid url: %w", err)
+	}
+	if c.ProxyURL != "" {
+		if _, err := url.Parse(c.ProxyURL); err != nil {
+			return fmt.Errorf("invalid proxy url: %w", err)
+		}
 	}
 	if c.Timeout == 0 {
 		return fmt.Errorf("missing timeout")
@@ -287,7 +296,7 @@ Token is a token to authenticate with the Piko server.`,
 		"connect.tenant-id",
 		c.TenantID,
 		`
-Tenant ID of the agent.
+Tenant ID of the agent (optional).
 
 Tenants can be used to configure different authentication mechanisms and keys
 for different upstream services.`,
@@ -304,6 +313,14 @@ reconnect.`,
 	)
 
 	c.TLS.RegisterFlags(fs, "connect")
+
+	fs.StringVar(
+		&c.ProxyURL,
+		"connect.proxy-url",
+		c.ProxyURL,
+		`
+The proxy URL to proxy the request from the agent to the Piko server (optional).`,
+	)
 }
 
 type ServerConfig struct {

--- a/cli/agent/command.go
+++ b/cli/agent/command.go
@@ -116,11 +116,21 @@ func runAgent(conf *config.Config, logger log.Logger) error {
 		// Already verified in conf.Validate() so this shouldn't happen.
 		return fmt.Errorf("connect url: %w", err)
 	}
+	var proxyURL *url.URL
+	if conf.Connect.ProxyURL != "" {
+		connectProxyURL, err := url.Parse(conf.Connect.ProxyURL)
+		if err != nil {
+			// Already verified in conf.Validate() so this shouldn't happen.
+			return fmt.Errorf("connect proxy url: %w", err)
+		}
+		proxyURL = connectProxyURL
+	}
 	upstream := &client.Upstream{
 		URL:       connectURL,
 		Token:     conf.Connect.Token,
 		TenantID:  conf.Connect.TenantID,
 		TLSConfig: connectTLSConfig,
+		ProxyURL:  proxyURL,
 		Logger:    logger.WithSubsystem("client"),
 	}
 

--- a/client/upstream.go
+++ b/client/upstream.go
@@ -54,6 +54,10 @@ type Upstream struct {
 	// If nil, the default configuration is used.
 	TLSConfig *tls.Config
 
+	// ProxyURL is the URL to proxy the request from the client to the Piko
+	// server (optional).
+	ProxyURL *url.URL
+
 	// MinReconnectBackoff is the minimum backoff when reconnecting.
 	//
 	// Defaults to 100ms.
@@ -120,6 +124,7 @@ func (u *Upstream) connect(ctx context.Context, endpointID string) (*yamux.Sessi
 			websocket.WithToken(u.Token),
 			websocket.WithTenantID(u.TenantID),
 			websocket.WithTLSConfig(u.TLSConfig),
+			websocket.WithProxyURL(u.ProxyURL),
 		)
 		if err == nil {
 			u.logger().Debug(


### PR DESCRIPTION
Adds support for the agent connecting to the Piko server via a HTTP proxy with '--connect.proxy-url'.

Fixes https://github.com/andydunstall/piko/issues/236.