### PR TITLE
Support the TLS config for the agent client

### DIFF
--- a/client/dialer.go
+++ b/client/dialer.go
@@ -43,6 +43,7 @@ func (d *Dialer) Dial(ctx context.Context, endpointID string) (net.Conn, error) 
 		ctx,
 		d.dialURL(endpointID),
 		websocket.WithToken(d.Token),
+		websocket.WithTLSConfig(d.TLSConfig),
 	)
 }
 


### PR DESCRIPTION
Just added this to allow for websocket connections with custom server cert (or other TLS config).

I maybe wrong but it feels like it's fixing a bug (disregarding the TLSConfig struct).

Tested manually.