### PR TITLE
Use proxy provided by environment

### DIFF
--- a/pkg/websocket/conn.go
+++ b/pkg/websocket/conn.go
@@ -113,6 +113,7 @@ func Dial(ctx context.Context, url string, opts ...DialOption) (*Conn, error) {
 	}
 
 	dialer := &websocket.Dialer{
+		Proxy:            http.ProxyFromEnvironment,
 		HandshakeTimeout: 60 * time.Second,
 	}
 


### PR DESCRIPTION
This allows the piko agent to easily connect to the connection server when placed behind a proxy.