### PR TITLE
auth: add require-endpoints option to enforce endpoint scoping in JWTs

### DIFF
--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -40,6 +40,14 @@ type Config struct {
 	// Piko still verifies the token expiry when the client first connects.
 	DisableDisconnectOnExpiry bool `json:"disable_disconnect_on_expiry" yaml:"disable_disconnect_on_expiry"`
 
+	// RequireEndpoints requires that authenticated JWTs include a non-empty
+	// 'piko.endpoints' claim.
+	//
+	// When enabled, tokens without an endpoints claim are rejected. This
+	// prevents clients from gaining access to all endpoints by omitting the
+	// claim.
+	RequireEndpoints bool `json:"require_endpoints" yaml:"require_endpoints"`
+
 	// JWKS is the JSON Web Key Set to use for verifying JWTs.
 	//
 	// If provided, it will take precedence over the other keys.
@@ -54,6 +62,7 @@ type LoadedConfig struct {
 	Audience                  string
 	Issuer                    string
 	DisableDisconnectOnExpiry bool
+	RequireEndpoints          bool
 	JWKS                      *LoadedJWKS
 }
 
@@ -70,6 +79,7 @@ func (c *Config) Load(ctx context.Context) (*LoadedConfig, error) {
 		Audience:                  c.Audience,
 		Issuer:                    c.Issuer,
 		DisableDisconnectOnExpiry: c.DisableDisconnectOnExpiry,
+		RequireEndpoints:          c.RequireEndpoints,
 	}
 
 	if c.RSAPublicKey != "" {
@@ -161,6 +171,16 @@ is ignored.`,
 Disables disconnecting the client when their token expires.
 
 Piko still verifies the token expiry when the client first connects.`,
+	)
+	fs.BoolVar(
+		&c.RequireEndpoints,
+		prefix+"require-endpoints",
+		c.RequireEndpoints,
+		`
+Requires that authenticated JWTs include a non-empty 'piko.endpoints' claim.
+
+When enabled, tokens without an endpoints claim are rejected. This prevents
+clients from gaining access to all endpoints by omitting the claim.`,
 	)
 
 	c.JWKS.RegisterFlags(fs, prefix)

--- a/pkg/auth/jwtverifier.go
+++ b/pkg/auth/jwtverifier.go
@@ -30,6 +30,7 @@ type JWTVerifier struct {
 	issuer   string
 
 	disableDisconnectOnExpiry bool
+	requireEndpoints          bool
 
 	// methods contains the valid JWT methods, which depends on the
 	// verification keys configured.
@@ -41,6 +42,7 @@ func NewJWTVerifier(conf *LoadedConfig) *JWTVerifier {
 		audience:                  conf.Audience,
 		issuer:                    conf.Issuer,
 		disableDisconnectOnExpiry: conf.DisableDisconnectOnExpiry,
+		requireEndpoints:          conf.RequireEndpoints,
 	}
 
 	if len(conf.HMACSecretKey) > 0 {
@@ -115,6 +117,10 @@ func (v *JWTVerifier) Verify(tokenString string) (*Token, error) {
 		return nil, ErrInvalidToken
 	}
 	if !token.Valid {
+		return nil, ErrInvalidToken
+	}
+
+	if v.requireEndpoints && len(claims.Piko.Endpoints) == 0 {
 		return nil, ErrInvalidToken
 	}
 


### PR DESCRIPTION
Without this option, a JWT with no 'piko.endpoints' claim is treated as granting access to all endpoints, and the target endpoint is determined entirely by the client-supplied 'x-piko-endpoint' header or Host subdomain. A leaked or broadly-issued token therefore becomes a wildcard pass to any endpoint on the server.

The new 'require_endpoints' config flag (--<prefix>.auth.require-endpoints) rejects tokens that omit the endpoints claim, ensuring every authenticated connection is explicitly scoped to a set of endpoints by the token issuer rather than relying on client-provided routing hints.