### PR TITLE
stream: support configuring maximum window size

### DIFF
--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -248,43 +248,38 @@ func (c *TLSConfig) Load() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-// MuxConfig contains tuning for the yamux multiplexer used between
-// the agent and the Piko server.
-type MuxConfig struct {
-	// MaxStreamWindowSize sets the yamux per-stream receive window in
-	// bytes. Throughput per stream is bounded by window/RTT.
+// StreamConfig configures the streams between the agent and Piko server.
+type StreamConfig struct {
+	// MaxWindowSize is the maximum receive window size in bytes.
 	//
-	// Set to 0 to use the yamux default (256 KiB). Must be >= 256 KiB
-	// when set.
-	MaxStreamWindowSize uint32 `json:"max_stream_window_size" yaml:"max_stream_window_size"`
+	// This is used for flow control to limit how much unread data can be
+	// in-flight on a stream. Increasing this value can increase the
+	// throughput from the server to the agent.
+	//
+	// Must be >=256KiB. Defaults to 256KiB.
+	MaxWindowSize uint32 `json:"max_window_size" yaml:"max_window_size"`
 }
 
-func (c *MuxConfig) Validate() error {
-	if c.MaxStreamWindowSize != 0 && c.MaxStreamWindowSize < 256*1024 {
-		return fmt.Errorf("max-stream-window-size must be >= 262144")
+func (c *StreamConfig) Validate() error {
+	if c.MaxWindowSize < 256*1024 {
+		return fmt.Errorf("max-window-size must be >= 262144")
 	}
 	return nil
 }
 
-func (c *MuxConfig) RegisterFlags(fs *pflag.FlagSet, prefix string) {
-	prefix = prefix + ".mux."
-
+func (c *StreamConfig) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Uint32Var(
-		&c.MaxStreamWindowSize,
-		prefix+"max-stream-window-size",
-		c.MaxStreamWindowSize,
+		&c.MaxWindowSize,
+		"stream.max-window-size",
+		c.MaxWindowSize,
 		`
-The yamux per-stream receive window in bytes used for the connection to
-the Piko server.
+MaxWindowSize is the maximum receive window size in bytes.
 
-Per-stream throughput is bounded by window-size / RTT, so increasing this
-value can improve single-stream throughput on high-RTT links at the cost
-of additional memory per stream.
+This is used for flow control to limit how much unread data can be
+in-flight on a stream. Increasing this value can increase the throughput
+from the server to the agent.
 
-Both server and agent must agree, as yamux negotiates the smaller of the
-two configured values.
-
-Set to 0 to use the yamux default (256 KiB). Must be >= 262144 when set.`,
+Must be >=256KiB. Defaults to 256KiB.`,
 	)
 }
 
@@ -305,8 +300,6 @@ type ConnectConfig struct {
 	Timeout time.Duration `json:"timeout" yaml:"timeout"`
 
 	TLS TLSConfig `json:"tls" yaml:"tls"`
-
-	Mux MuxConfig `json:"mux" yaml:"mux"`
 
 	// ProxyURL is the proxy URL to proxy the request from the agent to the
 	// Piko server (optional).
@@ -330,9 +323,6 @@ func (c *ConnectConfig) Validate() error {
 	}
 	if err := c.TLS.Validate(); err != nil {
 		return fmt.Errorf("tls: %w", err)
-	}
-	if err := c.Mux.Validate(); err != nil {
-		return fmt.Errorf("mux: %w", err)
 	}
 	return nil
 }
@@ -377,8 +367,6 @@ reconnect.`,
 	)
 
 	c.TLS.RegisterFlags(fs, "connect")
-
-	c.Mux.RegisterFlags(fs, "connect")
 
 	fs.StringVar(
 		&c.ProxyURL,
@@ -435,6 +423,8 @@ type Config struct {
 
 	Connect ConnectConfig `json:"connect" yaml:"connect"`
 
+	Stream StreamConfig `json:"stream" yaml:"stream"`
+
 	Server ServerConfig `json:"server" yaml:"server"`
 
 	Log log.Config `json:"log" yaml:"log"`
@@ -450,6 +440,9 @@ func Default() *Config {
 		Connect: ConnectConfig{
 			URL:     "http://localhost:8001",
 			Timeout: time.Second * 30,
+		},
+		Stream: StreamConfig{
+			MaxWindowSize: 256 * 1024,
 		},
 		Server: ServerConfig{
 			BindAddr: ":5000",
@@ -477,6 +470,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("connect: %w", err)
 	}
 
+	if err := c.Stream.Validate(); err != nil {
+		return fmt.Errorf("stream: %w", err)
+	}
+
 	if err := c.Server.Validate(); err != nil {
 		return fmt.Errorf("server: %w", err)
 	}
@@ -494,6 +491,7 @@ func (c *Config) Validate() error {
 
 func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	c.Connect.RegisterFlags(fs)
+	c.Stream.RegisterFlags(fs)
 	c.Server.RegisterFlags(fs)
 	c.Log.RegisterFlags(fs)
 

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -248,6 +248,46 @@ func (c *TLSConfig) Load() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+// MuxConfig contains tuning for the yamux multiplexer used between
+// the agent and the Piko server.
+type MuxConfig struct {
+	// MaxStreamWindowSize sets the yamux per-stream receive window in
+	// bytes. Throughput per stream is bounded by window/RTT.
+	//
+	// Set to 0 to use the yamux default (256 KiB). Must be >= 256 KiB
+	// when set.
+	MaxStreamWindowSize uint32 `json:"max_stream_window_size" yaml:"max_stream_window_size"`
+}
+
+func (c *MuxConfig) Validate() error {
+	if c.MaxStreamWindowSize != 0 && c.MaxStreamWindowSize < 256*1024 {
+		return fmt.Errorf("max-stream-window-size must be >= 262144")
+	}
+	return nil
+}
+
+func (c *MuxConfig) RegisterFlags(fs *pflag.FlagSet, prefix string) {
+	prefix = prefix + ".mux."
+
+	fs.Uint32Var(
+		&c.MaxStreamWindowSize,
+		prefix+"max-stream-window-size",
+		c.MaxStreamWindowSize,
+		`
+The yamux per-stream receive window in bytes used for the connection to
+the Piko server.
+
+Per-stream throughput is bounded by window-size / RTT, so increasing this
+value can improve single-stream throughput on high-RTT links at the cost
+of additional memory per stream.
+
+Both server and agent must agree, as yamux negotiates the smaller of the
+two configured values.
+
+Set to 0 to use the yamux default (256 KiB). Must be >= 262144 when set.`,
+	)
+}
+
 type ConnectConfig struct {
 	// URL is the Piko server URL to connect to.
 	URL string `json:"url" yaml:"url"`
@@ -265,6 +305,8 @@ type ConnectConfig struct {
 	Timeout time.Duration `json:"timeout" yaml:"timeout"`
 
 	TLS TLSConfig `json:"tls" yaml:"tls"`
+
+	Mux MuxConfig `json:"mux" yaml:"mux"`
 
 	// ProxyURL is the proxy URL to proxy the request from the agent to the
 	// Piko server (optional).
@@ -288,6 +330,9 @@ func (c *ConnectConfig) Validate() error {
 	}
 	if err := c.TLS.Validate(); err != nil {
 		return fmt.Errorf("tls: %w", err)
+	}
+	if err := c.Mux.Validate(); err != nil {
+		return fmt.Errorf("mux: %w", err)
 	}
 	return nil
 }
@@ -332,6 +377,8 @@ reconnect.`,
 	)
 
 	c.TLS.RegisterFlags(fs, "connect")
+
+	c.Mux.RegisterFlags(fs, "connect")
 
 	fs.StringVar(
 		&c.ProxyURL,

--- a/agent/config/config.go
+++ b/agent/config/config.go
@@ -248,6 +248,8 @@ func (c *TLSConfig) Load() (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
+const minStreamWindowSize = 256 * 1024
+
 // StreamConfig configures the streams between the agent and Piko server.
 type StreamConfig struct {
 	// MaxWindowSize is the maximum receive window size in bytes.
@@ -261,8 +263,8 @@ type StreamConfig struct {
 }
 
 func (c *StreamConfig) Validate() error {
-	if c.MaxWindowSize < 256*1024 {
-		return fmt.Errorf("max-window-size must be >= 262144")
+	if c.MaxWindowSize < minStreamWindowSize {
+		return fmt.Errorf("max-window-size must be >= %d", minStreamWindowSize)
 	}
 	return nil
 }
@@ -442,7 +444,7 @@ func Default() *Config {
 			Timeout: time.Second * 30,
 		},
 		Stream: StreamConfig{
-			MaxWindowSize: 256 * 1024,
+			MaxWindowSize: minStreamWindowSize,
 		},
 		Server: ServerConfig{
 			BindAddr: ":5000",

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -18,18 +18,6 @@ func TestConfig_Default(t *testing.T) {
 	assert.NoError(t, conf.Validate())
 }
 
-func TestStreamConfig_Validate(t *testing.T) {
-	t.Run("at minimum 256 KiB is allowed", func(t *testing.T) {
-		c := StreamConfig{MaxWindowSize: 256 * 1024}
-		assert.NoError(t, c.Validate())
-	})
-
-	t.Run("below 256 KiB is rejected", func(t *testing.T) {
-		c := StreamConfig{MaxWindowSize: 1024}
-		assert.Error(t, c.Validate())
-	})
-}
-
 func TestListenerConfig_URL(t *testing.T) {
 	tests := []struct {
 		addr string

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -18,6 +18,23 @@ func TestConfig_Default(t *testing.T) {
 	assert.NoError(t, conf.Validate())
 }
 
+func TestMuxConfig_Validate(t *testing.T) {
+	t.Run("zero is allowed (yamux default)", func(t *testing.T) {
+		c := MuxConfig{}
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("at minimum 256 KiB is allowed", func(t *testing.T) {
+		c := MuxConfig{MaxStreamWindowSize: 256 * 1024}
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("below 256 KiB is rejected", func(t *testing.T) {
+		c := MuxConfig{MaxStreamWindowSize: 1024}
+		assert.Error(t, c.Validate())
+	})
+}
+
 func TestListenerConfig_URL(t *testing.T) {
 	tests := []struct {
 		addr string
@@ -92,6 +109,8 @@ connect:
   url: 'http://localhost:8001'
   timeout: 30s
   token: cyz
+  mux:
+    max_stream_window_size: 4194304
 server:
   enabled: true
   bind_addr: ':5201'
@@ -142,6 +161,9 @@ log:
 			URL:     "http://localhost:8001",
 			Timeout: 30 * time.Second,
 			Token:   "cyz",
+			Mux: MuxConfig{
+				MaxStreamWindowSize: 4 * 1024 * 1024,
+			},
 		},
 		Server: ServerConfig{
 			Enabled:  true,

--- a/agent/config/config_test.go
+++ b/agent/config/config_test.go
@@ -18,19 +18,14 @@ func TestConfig_Default(t *testing.T) {
 	assert.NoError(t, conf.Validate())
 }
 
-func TestMuxConfig_Validate(t *testing.T) {
-	t.Run("zero is allowed (yamux default)", func(t *testing.T) {
-		c := MuxConfig{}
-		assert.NoError(t, c.Validate())
-	})
-
+func TestStreamConfig_Validate(t *testing.T) {
 	t.Run("at minimum 256 KiB is allowed", func(t *testing.T) {
-		c := MuxConfig{MaxStreamWindowSize: 256 * 1024}
+		c := StreamConfig{MaxWindowSize: 256 * 1024}
 		assert.NoError(t, c.Validate())
 	})
 
 	t.Run("below 256 KiB is rejected", func(t *testing.T) {
-		c := MuxConfig{MaxStreamWindowSize: 1024}
+		c := StreamConfig{MaxWindowSize: 1024}
 		assert.Error(t, c.Validate())
 	})
 }
@@ -109,8 +104,8 @@ connect:
   url: 'http://localhost:8001'
   timeout: 30s
   token: cyz
-  mux:
-    max_stream_window_size: 4194304
+stream:
+  max_window_size: 4194304
 server:
   enabled: true
   bind_addr: ':5201'
@@ -161,9 +156,9 @@ log:
 			URL:     "http://localhost:8001",
 			Timeout: 30 * time.Second,
 			Token:   "cyz",
-			Mux: MuxConfig{
-				MaxStreamWindowSize: 4 * 1024 * 1024,
-			},
+		},
+		Stream: StreamConfig{
+			MaxWindowSize: 4 * 1024 * 1024,
 		},
 		Server: ServerConfig{
 			Enabled:  true,

--- a/cli/agent/command.go
+++ b/cli/agent/command.go
@@ -139,13 +139,13 @@ func runAgent(conf *config.Config, logger log.Logger) error {
 		proxyURL = connectProxyURL
 	}
 	upstream := &client.Upstream{
-		URL:                 connectURL,
-		Token:               conf.Connect.Token,
-		TenantID:            conf.Connect.TenantID,
-		TLSConfig:           connectTLSConfig,
-		ProxyURL:            proxyURL,
-		MaxStreamWindowSize: conf.Connect.Mux.MaxStreamWindowSize,
-		Logger:              logger.WithSubsystem("client"),
+		URL:           connectURL,
+		Token:         conf.Connect.Token,
+		TenantID:      conf.Connect.TenantID,
+		TLSConfig:     connectTLSConfig,
+		ProxyURL:      proxyURL,
+		MaxWindowSize: conf.Stream.MaxWindowSize,
+		Logger:        logger.WithSubsystem("client"),
 	}
 
 	registry := prometheus.NewRegistry()

--- a/cli/agent/command.go
+++ b/cli/agent/command.go
@@ -139,12 +139,13 @@ func runAgent(conf *config.Config, logger log.Logger) error {
 		proxyURL = connectProxyURL
 	}
 	upstream := &client.Upstream{
-		URL:       connectURL,
-		Token:     conf.Connect.Token,
-		TenantID:  conf.Connect.TenantID,
-		TLSConfig: connectTLSConfig,
-		ProxyURL:  proxyURL,
-		Logger:    logger.WithSubsystem("client"),
+		URL:                 connectURL,
+		Token:               conf.Connect.Token,
+		TenantID:            conf.Connect.TenantID,
+		TLSConfig:           connectTLSConfig,
+		ProxyURL:            proxyURL,
+		MaxStreamWindowSize: conf.Connect.Mux.MaxStreamWindowSize,
+		Logger:              logger.WithSubsystem("client"),
 	}
 
 	registry := prometheus.NewRegistry()

--- a/client/upstream.go
+++ b/client/upstream.go
@@ -142,12 +142,14 @@ func (u *Upstream) connect(ctx context.Context, endpointID string) (*yamux.Sessi
 				zap.String("url", url),
 			)
 
+			maxWindowSize := u.MaxWindowSize
+			if maxWindowSize == 0 {
+				maxWindowSize = 256 * 1024
+			}
 			muxConfig := yamux.DefaultConfig()
 			muxConfig.Logger = nil
 			muxConfig.LogOutput = &yamuxLogWriter{logger: u.logger()}
-			if u.MaxWindowSize != 0 {
-				muxConfig.MaxStreamWindowSize = u.MaxWindowSize
-			}
+			muxConfig.MaxStreamWindowSize = maxWindowSize
 			sess, err := yamux.Client(conn, muxConfig)
 			if err != nil {
 				// Will not happen.

--- a/client/upstream.go
+++ b/client/upstream.go
@@ -15,6 +15,8 @@ import (
 	"github.com/andydunstall/piko/pkg/websocket"
 )
 
+const defaultMaxWindowSize = 256 * 1024
+
 var (
 	ErrClosed = errors.New("closed")
 )
@@ -144,7 +146,7 @@ func (u *Upstream) connect(ctx context.Context, endpointID string) (*yamux.Sessi
 
 			maxWindowSize := u.MaxWindowSize
 			if maxWindowSize == 0 {
-				maxWindowSize = 256 * 1024
+				maxWindowSize = defaultMaxWindowSize
 			}
 			muxConfig := yamux.DefaultConfig()
 			muxConfig.Logger = nil

--- a/client/upstream.go
+++ b/client/upstream.go
@@ -68,6 +68,19 @@ type Upstream struct {
 	// Defaults to 15s.
 	MaxReconnectBackoff time.Duration
 
+	// MaxStreamWindowSize sets the yamux per-stream receive window in bytes.
+	//
+	// Per-stream throughput is bounded by window-size / RTT, so a larger
+	// window can improve single-stream throughput on high-RTT links at the
+	// cost of additional memory per stream.
+	//
+	// Both server and upstream must agree, as yamux negotiates the smaller
+	// of the two configured values.
+	//
+	// Defaults to 0, meaning the yamux default (256 KiB). Must be >= 262144
+	// when set.
+	MaxStreamWindowSize uint32
+
 	// Logger is an optional logger to log connection state changes.
 	Logger Logger
 }
@@ -136,6 +149,9 @@ func (u *Upstream) connect(ctx context.Context, endpointID string) (*yamux.Sessi
 			muxConfig := yamux.DefaultConfig()
 			muxConfig.Logger = nil
 			muxConfig.LogOutput = &yamuxLogWriter{logger: u.logger()}
+			if u.MaxStreamWindowSize != 0 {
+				muxConfig.MaxStreamWindowSize = u.MaxStreamWindowSize
+			}
 			sess, err := yamux.Client(conn, muxConfig)
 			if err != nil {
 				// Will not happen.

--- a/client/upstream.go
+++ b/client/upstream.go
@@ -68,18 +68,14 @@ type Upstream struct {
 	// Defaults to 15s.
 	MaxReconnectBackoff time.Duration
 
-	// MaxStreamWindowSize sets the yamux per-stream receive window in bytes.
+	// MaxWindowSize is the maximum receive window size in bytes.
 	//
-	// Per-stream throughput is bounded by window-size / RTT, so a larger
-	// window can improve single-stream throughput on high-RTT links at the
-	// cost of additional memory per stream.
+	// This is used for flow control to limit how much unread data can be
+	// in-flight on a stream. Increasing this value can increase the
+	// throughput from the server to the client.
 	//
-	// Both server and upstream must agree, as yamux negotiates the smaller
-	// of the two configured values.
-	//
-	// Defaults to 0, meaning the yamux default (256 KiB). Must be >= 262144
-	// when set.
-	MaxStreamWindowSize uint32
+	// Must be >=256KiB. Defaults to 256KiB.
+	MaxWindowSize uint32
 
 	// Logger is an optional logger to log connection state changes.
 	Logger Logger
@@ -149,8 +145,8 @@ func (u *Upstream) connect(ctx context.Context, endpointID string) (*yamux.Sessi
 			muxConfig := yamux.DefaultConfig()
 			muxConfig.Logger = nil
 			muxConfig.LogOutput = &yamuxLogWriter{logger: u.logger()}
-			if u.MaxStreamWindowSize != 0 {
-				muxConfig.MaxStreamWindowSize = u.MaxStreamWindowSize
+			if u.MaxWindowSize != 0 {
+				muxConfig.MaxStreamWindowSize = u.MaxWindowSize
 			}
 			sess, err := yamux.Client(conn, muxConfig)
 			if err != nil {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -104,6 +104,8 @@ matter.`,
 	)
 }
 
+const minStreamWindowSize = 256 * 1024
+
 // StreamConfig configures the streams between the Piko server and upstream
 // listeners.
 type StreamConfig struct {
@@ -118,8 +120,8 @@ type StreamConfig struct {
 }
 
 func (c *StreamConfig) Validate() error {
-	if c.MaxWindowSize < 256*1024 {
-		return fmt.Errorf("max-window-size must be >= 262144")
+	if c.MaxWindowSize < minStreamWindowSize {
+		return fmt.Errorf("max-window-size must be >= %d", minStreamWindowSize)
 	}
 	return nil
 }
@@ -586,7 +588,7 @@ func Default() *Config {
 			},
 		},
 		Stream: StreamConfig{
-			MaxWindowSize: 256 * 1024,
+			MaxWindowSize: minStreamWindowSize,
 		},
 		Admin: AdminConfig{
 			BindAddr: ":8002",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -104,47 +104,39 @@ matter.`,
 	)
 }
 
-// MuxConfig contains tuning for the yamux multiplexer used between
-// upstream listeners and the server.
-type MuxConfig struct {
-	// MaxStreamWindowSize sets the yamux per-stream receive window in
-	// bytes. Throughput per stream is bounded by window/RTT.
+// StreamConfig configures the streams between the Piko server and upstream
+// listeners.
+type StreamConfig struct {
+	// MaxWindowSize is the maximum receive window size in bytes.
 	//
-	// Set to 0 to use the yamux default (256 KiB). Must be >= 256 KiB
-	// when set.
-	MaxStreamWindowSize uint32 `json:"max_stream_window_size" yaml:"max_stream_window_size"`
+	// This is used for flow control to limit how much unread data can be
+	// in-flight on a stream. Increasing this value can increase the
+	// throughput from the agent to the server.
+	//
+	// Must be >=256KiB. Defaults to 256KiB.
+	MaxWindowSize uint32 `json:"max_window_size" yaml:"max_window_size"`
 }
 
-func (c *MuxConfig) Validate() error {
-	if c.MaxStreamWindowSize != 0 && c.MaxStreamWindowSize < 256*1024 {
-		return fmt.Errorf("max-stream-window-size must be >= 262144")
+func (c *StreamConfig) Validate() error {
+	if c.MaxWindowSize < 256*1024 {
+		return fmt.Errorf("max-window-size must be >= 262144")
 	}
 	return nil
 }
 
-func (c *MuxConfig) RegisterFlags(fs *pflag.FlagSet, prefix string) {
-	if prefix == "" {
-		prefix = "mux."
-	} else {
-		prefix = prefix + ".mux."
-	}
-
+func (c *StreamConfig) RegisterFlags(fs *pflag.FlagSet) {
 	fs.Uint32Var(
-		&c.MaxStreamWindowSize,
-		prefix+"max-stream-window-size",
-		c.MaxStreamWindowSize,
+		&c.MaxWindowSize,
+		"stream.max-window-size",
+		c.MaxWindowSize,
 		`
-The yamux per-stream receive window in bytes used between upstream
-listeners and the server.
+MaxWindowSize is the maximum receive window size in bytes.
 
-Per-stream throughput is bounded by window-size / RTT, so increasing this
-value can improve single-stream throughput on high-RTT links at the cost
-of additional memory per stream.
+This is used for flow control to limit how much unread data can be
+in-flight on a stream. Increasing this value can increase the throughput
+from the agent to the server.
 
-Both server and upstream agent must agree, as yamux negotiates the smaller
-of the two configured values.
-
-Set to 0 to use the yamux default (256 KiB). Must be >= 262144 when set.`,
+Must be >=256KiB. Defaults to 256KiB.`,
 	)
 }
 
@@ -331,8 +323,6 @@ type UpstreamConfig struct {
 
 	Rebalance RebalanceConfig `json:"rebalance" yaml:"rebalance"`
 
-	Mux MuxConfig `json:"mux" yaml:"mux"`
-
 	TLS TLSConfig `json:"tls" yaml:"tls"`
 
 	// Tenants contains the list of supported tenants.
@@ -347,9 +337,6 @@ func (c *UpstreamConfig) Validate() error {
 	}
 	if err := c.Rebalance.Validate(); err != nil {
 		return fmt.Errorf("rebalance: %w", err)
-	}
-	if err := c.Mux.Validate(); err != nil {
-		return fmt.Errorf("mux: %w", err)
 	}
 	if err := c.TLS.Validate(); err != nil {
 		return fmt.Errorf("tls: %w", err)
@@ -393,8 +380,6 @@ advertise address of '10.26.104.14:8000'.`,
 	c.Auth.RegisterFlags(fs, "upstream")
 
 	c.Rebalance.RegisterFlags(fs, "upstream")
-
-	c.Mux.RegisterFlags(fs, "upstream")
 
 	c.TLS.RegisterFlags(fs, "upstream")
 }
@@ -560,6 +545,8 @@ type Config struct {
 
 	Upstream UpstreamConfig `json:"upstream" yaml:"upstream"`
 
+	Stream StreamConfig `json:"stream" yaml:"stream"`
+
 	Admin AdminConfig `json:"admin" yaml:"admin"`
 
 	Cluster ClusterConfig `json:"cluster" yaml:"cluster"`
@@ -598,6 +585,9 @@ func Default() *Config {
 				MinConns:  50,
 			},
 		},
+		Stream: StreamConfig{
+			MaxWindowSize: 256 * 1024,
+		},
 		Admin: AdminConfig{
 			BindAddr: ":8002",
 		},
@@ -630,6 +620,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("upstream: %w", err)
 	}
 
+	if err := c.Stream.Validate(); err != nil {
+		return fmt.Errorf("stream: %w", err)
+	}
+
 	if err := c.Admin.Validate(); err != nil {
 		return fmt.Errorf("admin: %w", err)
 	}
@@ -651,6 +645,8 @@ func (c *Config) RegisterFlags(fs *pflag.FlagSet) {
 	c.Proxy.RegisterFlags(fs)
 
 	c.Upstream.RegisterFlags(fs)
+
+	c.Stream.RegisterFlags(fs)
 
 	c.Admin.RegisterFlags(fs)
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -104,6 +104,50 @@ matter.`,
 	)
 }
 
+// MuxConfig contains tuning for the yamux multiplexer used between
+// upstream listeners and the server.
+type MuxConfig struct {
+	// MaxStreamWindowSize sets the yamux per-stream receive window in
+	// bytes. Throughput per stream is bounded by window/RTT.
+	//
+	// Set to 0 to use the yamux default (256 KiB). Must be >= 256 KiB
+	// when set.
+	MaxStreamWindowSize uint32 `json:"max_stream_window_size" yaml:"max_stream_window_size"`
+}
+
+func (c *MuxConfig) Validate() error {
+	if c.MaxStreamWindowSize != 0 && c.MaxStreamWindowSize < 256*1024 {
+		return fmt.Errorf("max-stream-window-size must be >= 262144")
+	}
+	return nil
+}
+
+func (c *MuxConfig) RegisterFlags(fs *pflag.FlagSet, prefix string) {
+	if prefix == "" {
+		prefix = "mux."
+	} else {
+		prefix = prefix + ".mux."
+	}
+
+	fs.Uint32Var(
+		&c.MaxStreamWindowSize,
+		prefix+"max-stream-window-size",
+		c.MaxStreamWindowSize,
+		`
+The yamux per-stream receive window in bytes used between upstream
+listeners and the server.
+
+Per-stream throughput is bounded by window-size / RTT, so increasing this
+value can improve single-stream throughput on high-RTT links at the cost
+of additional memory per stream.
+
+Both server and upstream agent must agree, as yamux negotiates the smaller
+of the two configured values.
+
+Set to 0 to use the yamux default (256 KiB). Must be >= 262144 when set.`,
+	)
+}
+
 // HTTPConfig contains generic configuration for the HTTP servers.
 type HTTPConfig struct {
 	// ReadTimeout is the maximum duration for reading the entire
@@ -287,6 +331,8 @@ type UpstreamConfig struct {
 
 	Rebalance RebalanceConfig `json:"rebalance" yaml:"rebalance"`
 
+	Mux MuxConfig `json:"mux" yaml:"mux"`
+
 	TLS TLSConfig `json:"tls" yaml:"tls"`
 
 	// Tenants contains the list of supported tenants.
@@ -301,6 +347,9 @@ func (c *UpstreamConfig) Validate() error {
 	}
 	if err := c.Rebalance.Validate(); err != nil {
 		return fmt.Errorf("rebalance: %w", err)
+	}
+	if err := c.Mux.Validate(); err != nil {
+		return fmt.Errorf("mux: %w", err)
 	}
 	if err := c.TLS.Validate(); err != nil {
 		return fmt.Errorf("tls: %w", err)
@@ -344,6 +393,8 @@ advertise address of '10.26.104.14:8000'.`,
 	c.Auth.RegisterFlags(fs, "upstream")
 
 	c.Rebalance.RegisterFlags(fs, "upstream")
+
+	c.Mux.RegisterFlags(fs, "upstream")
 
 	c.TLS.RegisterFlags(fs, "upstream")
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -21,6 +21,23 @@ func TestConfig_Default(t *testing.T) {
 	assert.NoError(t, conf.Validate())
 }
 
+func TestMuxConfig_Validate(t *testing.T) {
+	t.Run("zero is allowed (yamux default)", func(t *testing.T) {
+		c := MuxConfig{}
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("at minimum 256 KiB is allowed", func(t *testing.T) {
+		c := MuxConfig{MaxStreamWindowSize: 256 * 1024}
+		assert.NoError(t, c.Validate())
+	})
+
+	t.Run("below 256 KiB is rejected", func(t *testing.T) {
+		c := MuxConfig{MaxStreamWindowSize: 1024}
+		assert.Error(t, c.Validate())
+	})
+}
+
 // Tests loading the server configuration from YAML.
 func TestConfig_LoadYAML(t *testing.T) {
 	yaml := `
@@ -79,6 +96,9 @@ upstream:
     threshold: 0.2
     shed_rate: 0.005
     min_conns: 100
+
+  mux:
+    max_stream_window_size: 4194304
 
   tls:
     cert: /piko/cert.pem
@@ -196,6 +216,9 @@ grace_period: 2m
 				ShedRate:  0.005,
 				MinConns:  100,
 			},
+			Mux: MuxConfig{
+				MaxStreamWindowSize: 4 * 1024 * 1024,
+			},
 			TLS: TLSConfig{
 				Cert: "/piko/cert.pem",
 				Key:  "/piko/key.pem",
@@ -287,6 +310,7 @@ func TestConfig_LoadFlags(t *testing.T) {
 		"--upstream.rebalance.threshold", "0.2",
 		"--upstream.rebalance.shed-rate", "0.005",
 		"--upstream.rebalance.min-conns", "100",
+		"--upstream.mux.max-stream-window-size", "4194304",
 		"--upstream.auth.hmac-secret-key", "hmac-secret-key",
 		"--upstream.auth.rsa-public-key", "rsa-public-key",
 		"--upstream.auth.ecdsa-public-key", "ecdsa-public-key",
@@ -375,6 +399,9 @@ func TestConfig_LoadFlags(t *testing.T) {
 				Threshold: 0.2,
 				ShedRate:  0.005,
 				MinConns:  100,
+			},
+			Mux: MuxConfig{
+				MaxStreamWindowSize: 4 * 1024 * 1024,
 			},
 			TLS: TLSConfig{
 				Cert: "/piko/cert.pem",

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -21,19 +21,14 @@ func TestConfig_Default(t *testing.T) {
 	assert.NoError(t, conf.Validate())
 }
 
-func TestMuxConfig_Validate(t *testing.T) {
-	t.Run("zero is allowed (yamux default)", func(t *testing.T) {
-		c := MuxConfig{}
-		assert.NoError(t, c.Validate())
-	})
-
+func TestStreamConfig_Validate(t *testing.T) {
 	t.Run("at minimum 256 KiB is allowed", func(t *testing.T) {
-		c := MuxConfig{MaxStreamWindowSize: 256 * 1024}
+		c := StreamConfig{MaxWindowSize: 256 * 1024}
 		assert.NoError(t, c.Validate())
 	})
 
 	t.Run("below 256 KiB is rejected", func(t *testing.T) {
-		c := MuxConfig{MaxStreamWindowSize: 1024}
+		c := StreamConfig{MaxWindowSize: 1024}
 		assert.Error(t, c.Validate())
 	})
 }
@@ -97,9 +92,6 @@ upstream:
     shed_rate: 0.005
     min_conns: 100
 
-  mux:
-    max_stream_window_size: 4194304
-
   tls:
     cert: /piko/cert.pem
     key: /piko/key.pem
@@ -126,6 +118,9 @@ admin:
   tls:
     cert: /piko/cert.pem
     key: /piko/key.pem
+
+stream:
+  max_window_size: 4194304
 
 cluster:
   node_id: "my-node"
@@ -216,9 +211,6 @@ grace_period: 2m
 				ShedRate:  0.005,
 				MinConns:  100,
 			},
-			Mux: MuxConfig{
-				MaxStreamWindowSize: 4 * 1024 * 1024,
-			},
 			TLS: TLSConfig{
 				Cert: "/piko/cert.pem",
 				Key:  "/piko/key.pem",
@@ -237,6 +229,9 @@ grace_period: 2m
 					},
 				},
 			},
+		},
+		Stream: StreamConfig{
+			MaxWindowSize: 4 * 1024 * 1024,
 		},
 		Admin: AdminConfig{
 			BindAddr:      "10.15.104.25:8002",
@@ -310,7 +305,7 @@ func TestConfig_LoadFlags(t *testing.T) {
 		"--upstream.rebalance.threshold", "0.2",
 		"--upstream.rebalance.shed-rate", "0.005",
 		"--upstream.rebalance.min-conns", "100",
-		"--upstream.mux.max-stream-window-size", "4194304",
+		"--stream.max-window-size", "4194304",
 		"--upstream.auth.hmac-secret-key", "hmac-secret-key",
 		"--upstream.auth.rsa-public-key", "rsa-public-key",
 		"--upstream.auth.ecdsa-public-key", "ecdsa-public-key",
@@ -400,13 +395,13 @@ func TestConfig_LoadFlags(t *testing.T) {
 				ShedRate:  0.005,
 				MinConns:  100,
 			},
-			Mux: MuxConfig{
-				MaxStreamWindowSize: 4 * 1024 * 1024,
-			},
 			TLS: TLSConfig{
 				Cert: "/piko/cert.pem",
 				Key:  "/piko/key.pem",
 			},
+		},
+		Stream: StreamConfig{
+			MaxWindowSize: 4 * 1024 * 1024,
 		},
 		Admin: AdminConfig{
 			BindAddr:      "10.15.104.25:8002",

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -21,18 +21,6 @@ func TestConfig_Default(t *testing.T) {
 	assert.NoError(t, conf.Validate())
 }
 
-func TestStreamConfig_Validate(t *testing.T) {
-	t.Run("at minimum 256 KiB is allowed", func(t *testing.T) {
-		c := StreamConfig{MaxWindowSize: 256 * 1024}
-		assert.NoError(t, c.Validate())
-	})
-
-	t.Run("below 256 KiB is rejected", func(t *testing.T) {
-		c := StreamConfig{MaxWindowSize: 1024}
-		assert.Error(t, c.Validate())
-	})
-}
-
 // Tests loading the server configuration from YAML.
 func TestConfig_LoadYAML(t *testing.T) {
 	yaml := `

--- a/server/server.go
+++ b/server/server.go
@@ -193,6 +193,7 @@ func NewServer(conf *config.Config, logger log.Logger) (*Server, error) {
 		upstreamTLSConfig,
 		s.clusterState,
 		conf.Upstream,
+		conf.Stream,
 		logger,
 	)
 

--- a/server/upstream/server.go
+++ b/server/upstream/server.go
@@ -40,7 +40,8 @@ type Server struct {
 
 	cluster *cluster.State
 
-	config config.UpstreamConfig
+	config       config.UpstreamConfig
+	streamConfig config.StreamConfig
 
 	logger log.Logger
 }
@@ -51,6 +52,7 @@ func NewServer(
 	tlsConfig *tls.Config,
 	cluster *cluster.State,
 	config config.UpstreamConfig,
+	streamConfig config.StreamConfig,
 	logger log.Logger,
 ) *Server {
 	logger = logger.WithSubsystem("upstream")
@@ -70,6 +72,7 @@ func NewServer(
 		cancel:            cancel,
 		cluster:           cluster,
 		config:            config,
+		streamConfig:      streamConfig,
 		logger:            logger,
 	}
 
@@ -223,8 +226,8 @@ func (s *Server) upstreamRoute(c *gin.Context) {
 	muxConfig := yamux.DefaultConfig()
 	muxConfig.Logger = s.logger.StdLogger(zap.WarnLevel)
 	muxConfig.LogOutput = nil
-	if s.config.Mux.MaxStreamWindowSize != 0 {
-		muxConfig.MaxStreamWindowSize = s.config.Mux.MaxStreamWindowSize
+	if s.streamConfig.MaxWindowSize != 0 {
+		muxConfig.MaxStreamWindowSize = s.streamConfig.MaxWindowSize
 	}
 	sess, err := yamux.Server(conn, muxConfig)
 	if err != nil {

--- a/server/upstream/server.go
+++ b/server/upstream/server.go
@@ -223,6 +223,9 @@ func (s *Server) upstreamRoute(c *gin.Context) {
 	muxConfig := yamux.DefaultConfig()
 	muxConfig.Logger = s.logger.StdLogger(zap.WarnLevel)
 	muxConfig.LogOutput = nil
+	if s.config.Mux.MaxStreamWindowSize != 0 {
+		muxConfig.MaxStreamWindowSize = s.config.Mux.MaxStreamWindowSize
+	}
 	sess, err := yamux.Server(conn, muxConfig)
 	if err != nil {
 		// Will not happen.

--- a/server/upstream/server.go
+++ b/server/upstream/server.go
@@ -226,9 +226,7 @@ func (s *Server) upstreamRoute(c *gin.Context) {
 	muxConfig := yamux.DefaultConfig()
 	muxConfig.Logger = s.logger.StdLogger(zap.WarnLevel)
 	muxConfig.LogOutput = nil
-	if s.streamConfig.MaxWindowSize != 0 {
-		muxConfig.MaxStreamWindowSize = s.streamConfig.MaxWindowSize
-	}
+	muxConfig.MaxStreamWindowSize = s.streamConfig.MaxWindowSize
 	sess, err := yamux.Server(conn, muxConfig)
 	if err != nil {
 		// Will not happen.

--- a/server/upstream/server_test.go
+++ b/server/upstream/server_test.go
@@ -59,7 +59,7 @@ func TestServer_Register(t *testing.T) {
 
 		manager := newFakeManager()
 
-		s := NewServer(manager, nil, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, nil, nil, nil, config.UpstreamConfig{}, config.StreamConfig{MaxWindowSize: 256 * 1024}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -88,7 +88,7 @@ func TestServer_Register(t *testing.T) {
 
 		manager := newFakeManager()
 
-		s := NewServer(manager, nil, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, nil, nil, nil, config.UpstreamConfig{}, config.StreamConfig{MaxWindowSize: 256 * 1024}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -129,7 +129,7 @@ func TestServer_Authentication(t *testing.T) {
 			},
 		}, nil)
 
-		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{MaxWindowSize: 256 * 1024}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -168,7 +168,7 @@ func TestServer_Authentication(t *testing.T) {
 			},
 		}, nil)
 
-		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{MaxWindowSize: 256 * 1024}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -207,7 +207,7 @@ func TestServer_Authentication(t *testing.T) {
 			},
 		}, nil)
 
-		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{MaxWindowSize: 256 * 1024}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -238,7 +238,7 @@ func TestServer_Authentication(t *testing.T) {
 			},
 		}, nil)
 
-		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{MaxWindowSize: 256 * 1024}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -273,7 +273,7 @@ func TestServer_Authentication(t *testing.T) {
 			},
 		}, nil)
 
-		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{MaxWindowSize: 256 * 1024}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -300,7 +300,7 @@ func TestServer_TLS(t *testing.T) {
 
 	manager := newFakeManager()
 
-	s := NewServer(manager, nil, tlsConfig, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
+	s := NewServer(manager, nil, tlsConfig, nil, config.UpstreamConfig{}, config.StreamConfig{MaxWindowSize: 256 * 1024}, log.NewNopLogger())
 	go func() {
 		require.NoError(t, s.Serve(ln))
 	}()

--- a/server/upstream/server_test.go
+++ b/server/upstream/server_test.go
@@ -59,7 +59,7 @@ func TestServer_Register(t *testing.T) {
 
 		manager := newFakeManager()
 
-		s := NewServer(manager, nil, nil, nil, config.UpstreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, nil, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -88,7 +88,7 @@ func TestServer_Register(t *testing.T) {
 
 		manager := newFakeManager()
 
-		s := NewServer(manager, nil, nil, nil, config.UpstreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, nil, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -129,7 +129,7 @@ func TestServer_Authentication(t *testing.T) {
 			},
 		}, nil)
 
-		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -168,7 +168,7 @@ func TestServer_Authentication(t *testing.T) {
 			},
 		}, nil)
 
-		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -207,7 +207,7 @@ func TestServer_Authentication(t *testing.T) {
 			},
 		}, nil)
 
-		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -238,7 +238,7 @@ func TestServer_Authentication(t *testing.T) {
 			},
 		}, nil)
 
-		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -273,7 +273,7 @@ func TestServer_Authentication(t *testing.T) {
 			},
 		}, nil)
 
-		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, log.NewNopLogger())
+		s := NewServer(manager, verifier, nil, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
 		go func() {
 			require.NoError(t, s.Serve(ln))
 		}()
@@ -300,7 +300,7 @@ func TestServer_TLS(t *testing.T) {
 
 	manager := newFakeManager()
 
-	s := NewServer(manager, nil, tlsConfig, nil, config.UpstreamConfig{}, log.NewNopLogger())
+	s := NewServer(manager, nil, tlsConfig, nil, config.UpstreamConfig{}, config.StreamConfig{}, log.NewNopLogger())
 	go func() {
 		require.NoError(t, s.Serve(ln))
 	}()


### PR DESCRIPTION
## Motivation

Per-stream throughput across a piko tunnel is bounded by yamux's `MaxStreamWindowSize / RTT`. Both sides hard-code the yamux default of 256 KiB, capping a single stream at ~5 MB/s over a 50 ms RTT link regardless of available bandwidth.

## Change

Adds a top-level `stream` config block on each side, defaulting to the existing 256 KiB:

- Server: `stream.max_window_size` (YAML / `--stream.max-window-size`)
- `piko agent`: `stream.max_window_size` (YAML / `--stream.max-window-size`)
- Go SDK: `client.Upstream.MaxWindowSize`

Each side's `MaxWindowSize` is its local receive window, advertised to the peer via yamux window updates — so the two directions are independent.

## Tests

`make test` passes. End-to-end at 100 ms RTT: 20 × 1 MB sequential downloads improve **15.07 s → 2.71 s** with a 4 MiB window on the server.
