### PR TITLE
fix: correct occured to occurred typo in log config comment

### DIFF
--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -41,7 +41,7 @@ The available levels are 'debug', 'info', 'warn' and 'error'.`,
 		"log.subsystems",
 		c.Subsystems,
 		`
-Each log has a 'subsystem' field where the log occured.
+Each log has a 'subsystem' field where the log occurred.
 
 '--log.subsystems' enables all log levels for those given subsystems. This
 can be useful to debug a particular subsystem without having to enable all


### PR DESCRIPTION
Fixes a typo in pkg/log/config.go: 'occured' → 'occurred' in a documentation comment.

1 file, 1 line change.